### PR TITLE
Split platform-specific bootstrap into separate scripts

### DIFF
--- a/scripts/bootstrap.macos.sh
+++ b/scripts/bootstrap.macos.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# macOS-specific bootstrap: Xcode CLT, Homebrew, modern Bash.
+# Sourced by bootstrap.sh — runs BEFORE the Bash 4+ gate.
+# Must avoid Bash 4+ features (associative arrays, etc.)
+
+# Install Xcode Command Line Tools if missing
+if ! xcode-select -p &>/dev/null; then
+  log::info "Installing Xcode Command Line Tools..."
+  xcode-select --install
+  log::info "Waiting for Xcode CLT installation to complete..."
+  until xcode-select -p &>/dev/null; do
+    sleep 5
+  done
+  log::success "Xcode Command Line Tools installed"
+else
+  log::success "Xcode Command Line Tools already installed"
+fi
+
+# Install Homebrew if missing
+if ! platform::command_exists brew; then
+  log::info "Homebrew not found, installing..."
+  NONINTERACTIVE=1 /bin/bash -c \
+    "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  log::success "Homebrew installed"
+fi
+
+# Ensure Homebrew is on PATH (ARM vs Intel prefix)
+if [ -d /opt/homebrew ]; then
+  HOMEBREW_PREFIX=/opt/homebrew
+else
+  HOMEBREW_PREFIX=/usr/local
+fi
+eval "$("${HOMEBREW_PREFIX}/bin/brew" shellenv)"
+log::success "Homebrew on PATH (${HOMEBREW_PREFIX})"
+
+brew update
+
+# Upgrade Bash if system version is too old (< 4)
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  log::info "Bash ${BASH_VERSINFO:-unknown} is too old, installing modern Bash..."
+  brew install bash
+  log::success "Bash installed, re-executing with ${HOMEBREW_PREFIX}/bin/bash"
+  exec "${HOMEBREW_PREFIX}/bin/bash" "$0" "${BOOTSTRAP_ARGS[@]}"
+fi

--- a/scripts/bootstrap.ubuntu.sh
+++ b/scripts/bootstrap.ubuntu.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Linux-specific bootstrap: refresh package cache, install essentials.
+# Sourced by bootstrap.sh — runs BEFORE the Bash 4+ gate.
+# Must avoid Bash 4+ features (associative arrays, etc.)
+
+if platform::command_exists apt; then
+  log::info "Refreshing apt package cache..."
+  platform::sudo apt update -qq
+
+  # Install essential build tools if missing
+  for pkg in curl git build-essential; do
+    if ! dpkg -s "$pkg" &>/dev/null; then
+      log::info "Installing $pkg..."
+      platform::sudo apt install -qqy "$pkg"
+    fi
+  done
+  log::success "Essential packages available"
+fi


### PR DESCRIPTION
## Summary

- Extract macOS setup (Xcode CLT, Homebrew, Bash upgrade) into `scripts/bootstrap.macos.sh`
- Extract Ubuntu setup (apt cache refresh, essential packages) into `scripts/bootstrap.ubuntu.sh`
- Dispatch via existing `run()` helper using `platform::os`, matching the module `install.<platform>.sh` pattern
- Simplify Bash 4+ check to a pass/fail assertion after platform script runs