### PR TITLE
Symlink claude module into both ~/.claude/ and ~/.agents/

### DIFF
--- a/modules/claude/settings.json
+++ b/modules/claude/settings.json
@@ -78,6 +78,10 @@
     "type": "command",
     "command": "bash ~/.files/modules/claude/scripts/statusline.sh"
   },
+  "enabledPlugins": {
+    "swift-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true
+  },
   "alwaysThinkingEnabled": true,
   "defaultMode": "acceptEdits",
   "skipDangerousModePermissionPrompt": true,

--- a/modules/claude/setup.sh
+++ b/modules/claude/setup.sh
@@ -3,7 +3,7 @@
 ##? Setup Claude Code CLI
 ##?
 ##? Installs Claude Code via official installer and sets up the configuration directory.
-##? Uses ~/.agents/ as the canonical config directory with ~/.claude/ as a symlink.
+##? Config lives in modules/claude/; symlinks.conf links into ~/.claude/ and ~/.agents/.
 
 . "$DOTFILES/scripts/core/main.sh"
 
@@ -17,34 +17,7 @@ else
   claude --version 2>/dev/null || true
 fi
 
-# Ensure ~/.agents directory exists (symlinks will populate it)
-mkdir -p ~/.agents
-
-# Compatibility symlink: ~/.claude -> ~/.agents
-if [ -L ~/.claude ]; then
-  log::success "~/.claude symlink already exists"
-elif [ -d ~/.claude ]; then
-  log::info "Migrating ~/.claude/ contents to ~/.agents/"
-  # Move any non-symlinked files from .claude to .agents
-  for item in ~/.claude/*; do
-    [ -e "$item" ] || continue
-    base="$(basename "$item")"
-    if [ ! -e ~/.agents/"$base" ]; then
-      mv "$item" ~/.agents/"$base"
-    fi
-  done
-  rm -rf ~/.claude
-  ln -s .agents ~/.claude
-  log::success "Migrated ~/.claude/ to ~/.agents/ with symlink"
-else
-  ln -s .agents ~/.claude
-  log::success "Created ~/.claude -> ~/.agents symlink"
-fi
-
-# Compatibility symlink: ~/.agents/CLAUDE.md -> AGENTS.md
-if [ ! -L ~/.agents/CLAUDE.md ]; then
-  ln -sf AGENTS.md ~/.agents/CLAUDE.md
-  log::success "Created ~/.agents/CLAUDE.md -> AGENTS.md symlink"
-fi
+# Ensure target directories exist (symlinks.conf populates them)
+mkdir -p ~/.claude ~/.agents
 
 log::success "Claude Code setup complete"

--- a/modules/claude/skills/graph-design/SKILL.md
+++ b/modules/claude/skills/graph-design/SKILL.md
@@ -34,7 +34,7 @@ finalize(
 ### Title stack (top → bottom)
 
 ```
-────        short red rule  (#bf352b, 3.5 lw)
+────────    short red rule  (#bf352b, 3.5 lw, 80 px)
 Title       IBM Plex Sans Bold, 12 pt
 Descriptor  IBM Plex Sans Regular, 9.5 pt
 ```

--- a/modules/claude/skills/graph-design/graph_design/_finalize.py
+++ b/modules/claude/skills/graph-design/graph_design/_finalize.py
@@ -21,7 +21,7 @@ def finalize(
 
     Title stack (top to bottom)::
 
-        ----        short red rule
+        ────        short red rule
         Title       IBM Plex Sans Bold
         Descriptor  IBM Plex Sans Regular
 
@@ -47,7 +47,7 @@ def finalize(
         ax.spines["right"].set_linewidth(0)
         ax.spines["left"].set_visible(False)
 
-    ax.yaxis.set_tick_params(pad=-2, labelsize=9)
+    ax.yaxis.set_tick_params(pad=4, labelsize=9)
     ax.spines["bottom"].set_color(C_SPINE)
     ax.spines["bottom"].set_linewidth(1.0)
 
@@ -89,8 +89,8 @@ def finalize(
         )
         y_cursor += 0.040 + rule_gap
 
-    # Short red rule at the top (~40 px wide)
-    rule_w = 40 / (fig.get_figwidth() * fig.dpi)
+    # Short red rule at the top (~80 px wide)
+    rule_w = 80 / (fig.get_figwidth() * fig.dpi)
     fig.add_artist(
         plt.Line2D(
             [tx, tx + rule_w],

--- a/modules/claude/symlinks.conf
+++ b/modules/claude/symlinks.conf
@@ -3,3 +3,8 @@ settings.json -> ~/.agents/settings.json
 skills -> ~/.agents/skills
 commands -> ~/.agents/commands
 mcp.json -> ~/.agents/mcp.json
+AGENTS.md -> ~/.claude/CLAUDE.md
+settings.json -> ~/.claude/settings.json
+skills -> ~/.claude/skills
+commands -> ~/.claude/commands
+mcp.json -> ~/.claude/mcp.json

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -84,6 +84,7 @@ link::extract_and_link() {
   local sep=' -> '
   while read -r line || [[ -n "$line" ]]
   do
+    [[ -z "$line" ]] && continue
     local src=${line%%$sep*}
     local dst=${line#*$sep}
     link::file "$(dirname "$1")/$src" "${dst/#\~/$HOME}"


### PR DESCRIPTION
## Summary
- modules/claude/ is the canonical source for config
- symlinks.conf now creates links in both ~/.claude/ and ~/.agents/
- link::extract_and_link supports multiple destinations per source file

Replaces the old approach of making ~/.claude a symlink to ~/.agents.