### PR TITLE
feat(install): install identical toolchain on Linux and macOS

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,7 +33,7 @@ parse_args() {
             allModules=true
           ;;
           -c|--cli)
-            scanned_valid_modules+=("$DOTFILES/modules/zsh" "$DOTFILES/modules/ssh" "$DOTFILES/modules/git" "$DOTFILES/modules/python" "$DOTFILES/modules/piknik" "$DOTFILES/modules/tailscale" "$DOTFILES/modules/cloudflared" "$DOTFILES/modules/claude")
+            scanned_valid_modules+=("$DOTFILES/modules/zsh" "$DOTFILES/modules/ssh" "$DOTFILES/modules/git" "$DOTFILES/modules/python" "$DOTFILES/modules/node" "$DOTFILES/modules/piknik" "$DOTFILES/modules/tailscale" "$DOTFILES/modules/cloudflared" "$DOTFILES/modules/claude")
           ;;
           *)
             if [ -d "$DOTFILES/modules/$1" ]; then

--- a/modules/claude/bin/trash
+++ b/modules/claude/bin/trash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Minimal `trash`: move paths into a trash directory instead of deleting them,
+# so an accidental removal stays recoverable. The macOS `trash` (macos-trash)
+# uses the real Finder Trash; on Linux this is the dependency-free equivalent.
+# Override the destination with $TRASH_DIR (default: /tmp/trash).
+set -euo pipefail
+
+dest="${TRASH_DIR:-/tmp/trash}"
+mkdir -p "$dest"
+
+if [ "$#" -eq 0 ]; then
+  printf 'usage: trash <path>...\n' >&2
+  exit 1
+fi
+
+for path in "$@"; do
+  if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+    printf 'trash: %s: no such file or directory\n' "$path" >&2
+    continue
+  fi
+  target="$dest/$(basename "$path")"
+  # Don't clobber an earlier trashed file of the same name.
+  suffix=1
+  while [ -e "$target" ]; do
+    target="$dest/$(basename "$path").$suffix"
+    suffix=$((suffix + 1))
+  done
+  mv "$path" "$target"
+done

--- a/modules/claude/install.macos.sh
+++ b/modules/claude/install.macos.sh
@@ -1,8 +1,6 @@
+# shellcheck shell=bash
 . "$DOTFILES/scripts/core/main.sh"
 
+# GUI terminal — macOS only. The CLI tools (actionlint, zizmor, …) are now
+# cross-platform in install.sh; Node + pnpm live in the `node` module.
 install::cask "Ghostty" "ghostty"
-
-install::package "actionlint" "actionlint"
-install::package "zizmor" "zizmor"
-install::package "Node.js 22" "node@22"
-install::package "pnpm" "pnpm"

--- a/modules/claude/install.sh
+++ b/modules/claude/install.sh
@@ -1,13 +1,46 @@
+# shellcheck shell=bash
 . "$DOTFILES/scripts/core/main.sh"
+
+# Prefer Homebrew (macOS always; Linux too when Linuxbrew is present). Fall back
+# to a prebuilt GitHub-release binary only when brew is unavailable — e.g. a bare
+# Linux box where these tools have no apt package.
+claude::install_tool() { # readable_name cmd repo url_template
+  if platform::command_exists "$2"; then
+    log::success "$1"
+  elif platform::command_exists brew; then
+    log::execute "brew install $2" "$1"
+  else
+    install::release_binary "$1" "$2" "$3" "$4"
+  fi
+}
 
 install::package "jq" "jq"
 install::package "ripgrep" "ripgrep"
-install::package "fd" "fd"
-install::package "ast-grep" "ast-grep"
 install::package "shellcheck" "shellcheck"
-install::package "shfmt" "shfmt"
+
+# fd: apt ships it as `fd-find` (binary `fdfind`); expose the canonical `fd`.
+if platform::is_osx; then
+  install::package "fd" "fd"
+else
+  install::package "fd-find" "fd-find"
+  platform::command_exists fd || platform::relink "fdfind" "fd"
+fi
+
+claude::install_tool "ast-grep" "ast-grep" "ast-grep/ast-grep" \
+  "https://github.com/ast-grep/ast-grep/releases/download/@TAG@/app-@ARCH_GNU@-unknown-linux-gnu.zip"
+claude::install_tool "shfmt" "shfmt" "mvdan/sh" \
+  "https://github.com/mvdan/sh/releases/download/@TAG@/shfmt_@TAG@_linux_@ARCH_DEB@"
+claude::install_tool "actionlint" "actionlint" "rhysd/actionlint" \
+  "https://github.com/rhysd/actionlint/releases/download/@TAG@/actionlint_@VER@_linux_@ARCH_DEB@.tar.gz"
+claude::install_tool "zizmor" "zizmor" "zizmorcore/zizmor" \
+  "https://github.com/zizmorcore/zizmor/releases/download/@TAG@/zizmor-@ARCH_GNU@-unknown-linux-gnu.tar.gz"
+
+# trash: macos-trash provides `trash` (real Finder Trash). On Linux, link the
+# repo's shim, which moves paths to $TRASH_DIR (default /tmp/trash).
 if platform::is_osx; then
   install::package "macos-trash" "macos-trash"
-elif platform::is_linux; then
-  install::package "trash-cli" "trash-cli"
+else
+  mkdir -p "$HOME/.local/bin"
+  ln -sfn "$DOTFILES/modules/claude/bin/trash" "$HOME/.local/bin/trash"
+  log::success "trash (mv to \${TRASH_DIR:-/tmp/trash})"
 fi

--- a/modules/git/gitconfig
+++ b/modules/git/gitconfig
@@ -280,7 +280,7 @@
 	rebase = true
 [credential "https://github.com"]
 	helper = 
-	helper = !/opt/homebrew/bin/gh auth git-credential
+	helper = !gh auth git-credential
 [credential "https://gist.github.com"]
 	helper = 
-	helper = !/opt/homebrew/bin/gh auth git-credential
+	helper = !gh auth git-credential

--- a/modules/git/setup.github.sh
+++ b/modules/git/setup.github.sh
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
 
+github::install_cli() {
+  if platform::command_exists gh; then
+    log::success "GitHub CLI"
+    return 0
+  fi
+  if platform::is_osx; then
+    install::package "GitHub CLI" "gh"
+    return $?
+  fi
+  # Linux: gh is absent from the default apt repos — add the official one.
+  log::info "Adding the GitHub CLI apt repository..."
+  platform::sudo mkdir -p -m 755 /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | platform::sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  platform::sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  printf 'deb [arch=%s signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n' \
+    "$(dpkg --print-architecture)" \
+    | platform::sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+  platform::sudo apt update -qq
+  install::package "GitHub CLI" "gh"
+}
+
 github::add_ssh_configs() {
 
     printf "%s\n" \

--- a/modules/git/setup.sh
+++ b/modules/git/setup.sh
@@ -31,7 +31,7 @@ setup_gitconfig
 
 install::package "Git LFS" "git-lfs"
 install::package "Transcrypt" "transcrypt"
-install::package "Github CLI" "gh"
+github::install_cli
 
 if [ "$skipQuestions" != true ]; then
   feedback::ask_for_confirmation "Do you want to setup github?"

--- a/modules/node/install.sh
+++ b/modules/node/install.sh
@@ -1,10 +1,27 @@
 # shellcheck shell=bash
 . "$DOTFILES/scripts/core/main.sh"
 
-install::package "Node.js" "node"
-
-if command -v pnpm &>/dev/null; then
-  log::success "pnpm"
+# Node 22 LTS on both platforms. Skip if a new-enough node is already present.
+if platform::command_exists node \
+  && node --version | grep -qE '^v(2[2-9]|[3-9][0-9])\.'; then
+  log::success "Node.js $(node --version)"
+elif platform::is_osx; then
+  install::package "Node.js 22" "node@22"
+  brew link --overwrite --force node@22 >/dev/null 2>&1 || true
 else
-  log::execute "npm install -g pnpm" "pnpm"
+  log::info "Installing Node.js 22 (NodeSource)..."
+  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash -
+  install::package "Node.js" "nodejs"
+fi
+
+# pnpm via corepack (bundled with Node ≥16); npm global as a fallback. brew's
+# node bin dir is user-writable, so only Linux's system prefix needs sudo.
+if platform::command_exists pnpm; then
+  log::success "pnpm"
+elif platform::is_osx; then
+  corepack enable pnpm 2>/dev/null || npm install -g pnpm
+  log::result $? "pnpm"
+else
+  sudo corepack enable pnpm 2>/dev/null || sudo npm install -g pnpm
+  log::result $? "pnpm"
 fi

--- a/scripts/core/install.sh
+++ b/scripts/core/install.sh
@@ -33,3 +33,82 @@ install::snap() {
 install::cask() {
   install::with "brew" "$1" "$2" "$3" "--cask"
 }
+
+# Install a single executable from a GitHub release. Use on Linux for tools that
+# ship no apt package; on macOS the caller should use brew instead. URL_TEMPLATE
+# may contain these placeholders, substituted before download:
+#   @TAG@       full release tag       (e.g. v3.13.1)
+#   @VER@       tag without leading v  (e.g. 3.13.1)
+#   @ARCH_DEB@  amd64 | arm64          (Go / dpkg arch naming)
+#   @ARCH_GNU@  x86_64 | aarch64       (Rust / GNU arch naming)
+# TAG defaults to the repo's latest release; pass a 5th arg to pin it. .tar.gz
+# and .zip assets are unpacked and CMD is located inside them; any other asset
+# installs directly. Lands in ~/.local/bin (on PATH, no sudo). No-op if present.
+install::release_binary() {
+  local -r readable_name="$1"
+  local -r cmd="$2"
+  local -r repo="$3"
+  local -r url_template="$4"
+  local tag="${5:-}"
+
+  if platform::command_exists "$cmd"; then
+    log::success "$readable_name"
+    return 0
+  fi
+
+  if [ -z "$tag" ]; then
+    tag="$(curl -fsSL "https://api.github.com/repos/${repo}/releases/latest" \
+      | grep -m1 '"tag_name"' \
+      | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')"
+  fi
+  if [ -z "$tag" ]; then
+    log::error "$readable_name: could not resolve a release for $repo"
+    return 1
+  fi
+
+  local arch_deb arch_gnu
+  case "$(uname -m)" in
+    x86_64 | amd64) arch_deb="amd64"; arch_gnu="x86_64" ;;
+    aarch64 | arm64) arch_deb="arm64"; arch_gnu="aarch64" ;;
+    *) log::error "$readable_name: unsupported architecture $(uname -m)"; return 1 ;;
+  esac
+
+  local url="$url_template"
+  url="${url//@TAG@/$tag}"
+  url="${url//@VER@/${tag#v}}"
+  url="${url//@ARCH_DEB@/$arch_deb}"
+  url="${url//@ARCH_GNU@/$arch_gnu}"
+
+  local tmp archive src
+  tmp="$(mktemp -d)"
+  archive="$tmp/${url##*/}"
+
+  if ! curl -fsSL "$url" -o "$archive"; then
+    log::error "$readable_name: download failed ($url)"
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  case "$archive" in
+    *.tar.gz | *.tgz) tar -xzf "$archive" -C "$tmp" ;;
+    *.zip)
+      platform::command_exists unzip || install::package "unzip" "unzip"
+      unzip -qo "$archive" -d "$tmp"
+      ;;
+    *) src="$archive" ;;
+  esac
+  [ -n "${src:-}" ] || src="$(find "$tmp" -type f -name "$cmd" -print -quit)"
+
+  if [ -z "${src:-}" ] || [ ! -f "$src" ]; then
+    log::error "$readable_name: '$cmd' not found in $url"
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  mkdir -p "$HOME/.local/bin"
+  install -m 0755 "$src" "$HOME/.local/bin/$cmd"
+  local -r rc=$?
+  rm -rf "$tmp"
+  log::result "$rc" "$readable_name ($tag)"
+  return "$rc"
+}


### PR DESCRIPTION
Makes the dotfiles install the same CLI toolchain on Linux as on macOS — `gh`, `ast-grep`, `shfmt`, `actionlint`, `zizmor`, Node 22 + pnpm, and `trash` previously installed only via Homebrew on macOS (or failed-soft on Ubuntu).

## What

- **`scripts/core/install.sh`**: new `install::release_binary` helper — installs a binary from a GitHub release (arch-aware amd64/arm64 + x86_64/aarch64, unpacks `.tar.gz`/`.zip` or installs raw, latest tag by default, pinnable). Lands in `~/.local/bin`.
- **`modules/claude/install.sh`**: prefer Homebrew (mac always, Linuxbrew if present); fall back to a release binary **only when brew is absent**. `ast-grep`/`shfmt`/`actionlint`/`zizmor` now cross-platform; `fd` via `fd-find`.
- **`modules/claude/bin/trash`**: dependency-free `trash` shim that `mv`s into `$TRASH_DIR` (default `/tmp/trash`) — replaces the `trash-cli` dependency on Linux. macOS keeps `macos-trash`.
- **`modules/node/install.sh`**: Node 22 (NodeSource on Linux, `node@22` on mac) + pnpm via corepack.
- **`bootstrap.sh`**: add `node` to the `--cli` set.
- **`modules/git/{setup.sh,setup.github.sh}`**: install `gh` from the official apt repo on Linux.
- **`modules/git/gitconfig`**: credential helper now `!gh auth git-credential` (PATH-resolved) instead of the hardcoded macOS `/opt/homebrew/bin/gh`.

## Test

- `install::release_binary` validated end-to-end for raw / `.tar.gz` / `.zip` assets (real Linux x86_64 binaries fetched).
- `trash` shim: moves files, suffixes name collisions, errors on missing paths.
- `shellcheck` + `bash -n` clean on all changed scripts.