### PR TITLE
refactor(install): fold brew preference into install::release_binary

### DIFF
--- a/modules/claude/install.sh
+++ b/modules/claude/install.sh
@@ -1,19 +1,6 @@
 # shellcheck shell=bash
 . "$DOTFILES/scripts/core/main.sh"
 
-# Prefer Homebrew (macOS always; Linux too when Linuxbrew is present). Fall back
-# to a prebuilt GitHub-release binary only when brew is unavailable — e.g. a bare
-# Linux box where these tools have no apt package.
-claude::install_tool() { # readable_name cmd repo url_template
-  if platform::command_exists "$2"; then
-    log::success "$1"
-  elif platform::command_exists brew; then
-    log::execute "brew install $2" "$1"
-  else
-    install::release_binary "$1" "$2" "$3" "$4"
-  fi
-}
-
 install::package "jq" "jq"
 install::package "ripgrep" "ripgrep"
 install::package "shellcheck" "shellcheck"
@@ -26,13 +13,14 @@ else
   platform::command_exists fd || platform::relink "fdfind" "fd"
 fi
 
-claude::install_tool "ast-grep" "ast-grep" "ast-grep/ast-grep" \
+# brew when available, else a prebuilt GitHub-release binary (see the helper).
+install::release_binary "ast-grep" "ast-grep" "ast-grep/ast-grep" \
   "https://github.com/ast-grep/ast-grep/releases/download/@TAG@/app-@ARCH_GNU@-unknown-linux-gnu.zip"
-claude::install_tool "shfmt" "shfmt" "mvdan/sh" \
+install::release_binary "shfmt" "shfmt" "mvdan/sh" \
   "https://github.com/mvdan/sh/releases/download/@TAG@/shfmt_@TAG@_linux_@ARCH_DEB@"
-claude::install_tool "actionlint" "actionlint" "rhysd/actionlint" \
+install::release_binary "actionlint" "actionlint" "rhysd/actionlint" \
   "https://github.com/rhysd/actionlint/releases/download/@TAG@/actionlint_@VER@_linux_@ARCH_DEB@.tar.gz"
-claude::install_tool "zizmor" "zizmor" "zizmorcore/zizmor" \
+install::release_binary "zizmor" "zizmor" "zizmorcore/zizmor" \
   "https://github.com/zizmorcore/zizmor/releases/download/@TAG@/zizmor-@ARCH_GNU@-unknown-linux-gnu.tar.gz"
 
 # trash: macos-trash provides `trash` (real Finder Trash). On Linux, link the

--- a/scripts/core/install.sh
+++ b/scripts/core/install.sh
@@ -34,9 +34,11 @@ install::cask() {
   install::with "brew" "$1" "$2" "$3" "--cask"
 }
 
-# Install a single executable from a GitHub release. Use on Linux for tools that
-# ship no apt package; on macOS the caller should use brew instead. URL_TEMPLATE
-# may contain these placeholders, substituted before download:
+# Install a developer CLI tool, preferring Homebrew (macOS always; Linux only
+# when Linuxbrew is present) and falling back to a prebuilt GitHub-release binary
+# only when brew is unavailable — e.g. a bare Linux box where the tool has no apt
+# package. URL_TEMPLATE may contain these placeholders, substituted before the
+# fallback download:
 #   @TAG@       full release tag       (e.g. v3.13.1)
 #   @VER@       tag without leading v  (e.g. 3.13.1)
 #   @ARCH_DEB@  amd64 | arm64          (Go / dpkg arch naming)
@@ -54,6 +56,11 @@ install::release_binary() {
   if platform::command_exists "$cmd"; then
     log::success "$readable_name"
     return 0
+  fi
+
+  if platform::command_exists brew; then
+    log::execute "brew install $cmd" "$readable_name"
+    return $?
   fi
 
   if [ -z "$tag" ]; then


### PR DESCRIPTION
Follow-up to #7. The `claude::install_tool` wrapper was generic logic (prefer brew, else a GitHub-release binary) wearing a `claude::` module namespace — inconsistent with the dotfiles convention where generic install helpers live in `scripts/core/install.sh` as `install::*`.

- Move the brew-preference into `install::release_binary` (it already short-circuits when the command exists; checking brew next is the natural place).
- Delete `claude::install_tool`; the 4 call sites (`ast-grep`/`shfmt`/`actionlint`/`zizmor`) call `install::release_binary` directly.

Behaviour unchanged: brew on macOS/Linuxbrew, release binary only when brew is absent. `shellcheck` + `bash -n` clean; release-binary fallback re-verified end-to-end.