### PR TITLE
fix(install): avoid curl SIGPIPE (exit 23) in release-binary tag fetch

### DIFF
--- a/scripts/core/install.sh
+++ b/scripts/core/install.sh
@@ -64,8 +64,12 @@ install::release_binary() {
   fi
 
   if [ -z "$tag" ]; then
-    tag="$(curl -fsSL "https://api.github.com/repos/${repo}/releases/latest" \
-      | grep -m1 '"tag_name"' \
+    # Buffer the API response before matching: piping curl straight into
+    # `grep -m1` makes grep close the pipe on the first match, leaving curl to
+    # die with SIGPIPE ("curl: (23) Failure writing output to destination").
+    local api
+    api="$(curl -fsSL "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null)"
+    tag="$(printf '%s' "$api" | grep -m1 '"tag_name"' \
       | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')"
   fi
   if [ -z "$tag" ]; then


### PR DESCRIPTION
Follow-up to #7/#8. `install::release_binary` piped `curl` straight into `grep -m1`, so grep closed the pipe after the first match and curl died with SIGPIPE — printing `curl: (23) Failure writing output to destination` on every install (harmless, but noisy and trips the zero-warnings bar).

Buffer the API response into a variable first, then match. Verified on real Linux (bonbon): tag still resolves and the install runs with clean stderr.