### PR TITLE
feat(zsh): portable fzf config + drop experiment-log auto-stub

### DIFF
--- a/modules/claude/hooks/experiment-log.sh
+++ b/modules/claude/hooks/experiment-log.sh
@@ -157,22 +157,18 @@ write_entry() { # <title> <body>
   } >>"$LOG"
 }
 
-STAMP=$(date '+%Y-%m-%d %H:%M')
-
 # --- Stage 1: Haiku draft ---
 SYS_DRAFT='You write a DETAILED, operational lab-notebook draft for ONE work turn. The input is the turn transcript (a user request, then the assistant'"'"'s actions and final reply, with [tool:Name] markers for tool calls). Capture what actually happened, blow-by-blow and warts-and-all: the request/intent; concrete actions (files created/edited with paths, commands run, key code/config/prompt changes); decisions and the reasoning behind them; bugs, errors, dead-ends and how they were resolved; results and measurements (numbers, AUROCs, pass/fail); and anything left open. Be specific — paths, flags, identifiers, error messages, figures. Output Markdown: line 1 a short title (max 70 chars, no leading "#"), then a blank line, then as many "- " bullets as the work needs (sub-bullets allowed). Prefer completeness over brevity here; a later pass will distil it. No preamble, no sign-off.'
 
 DRAFT=""
 [[ -n "$KEY" && -n "$TURN" ]] && DRAFT=$(anthropic_call "$DRAFT_MODEL" "$SYS_DRAFT" "$TURN" 1500)
 
-# Offline / no-draft fallback: naive trimmed stub, then done.
+# No draft (no API key, or the summariser call failed/returned empty — e.g.
+# rate-limited during a heavy sweep): skip silently. Emitting a naive stub here
+# produced low-value "Auto-stub" entries that had to be cleaned up by hand;
+# recording nothing is better than recording junk. State still advances so the
+# turn isn't reprocessed on the next Stop.
 if [[ -z "$DRAFT" ]]; then
-  {
-    printf '\n## %s — %s\n\n' "$STAMP" "$(trim "${USER_MSG:-session turn}" 80)"
-    printf '_Auto-stub (no summariser) — flesh out warts-and-all._\n\n'
-    printf -- '- Request: %s\n' "$(trim "${USER_MSG:-(none captured)}")"
-    printf -- '- Outcome: %s\n' "$(trim "${ASSISTANT_MSG:-(none captured)}")"
-  } >>"$LOG"
   save_state
   exit 0
 fi

--- a/modules/zsh/fzf.zsh
+++ b/modules/zsh/fzf.zsh
@@ -1,0 +1,133 @@
+# FZF Configuration
+# =================
+
+# Check if fzf is installed
+if ! command -v fzf &> /dev/null; then
+  return
+fi
+
+# Core FZF settings
+export FZF_DEFAULT_OPTS="
+  --height 50%
+  --layout=reverse
+  --border rounded
+  --info=inline
+  --margin=1
+  --padding=1
+  --bind 'ctrl-/:toggle-preview'
+  --bind 'ctrl-y:execute-silent(echo -n {2..} | cb)+abort'
+  --bind 'ctrl-a:select-all'
+  --bind 'ctrl-d:deselect-all'
+  --preview-window=right:50%:wrap
+"
+
+# Use fd if available, otherwise fall back to find
+if command -v fd &> /dev/null; then
+  export FZF_DEFAULT_COMMAND='fd --type f --strip-cwd-prefix --hidden --follow --exclude .git'
+  export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+  export FZF_ALT_C_COMMAND='fd --type d --strip-cwd-prefix --hidden --follow --exclude .git'
+fi
+
+# CTRL-T: Paste selected files into command line
+export FZF_CTRL_T_OPTS="
+  --preview 'command -v bat &>/dev/null && bat -n --color=always {} 2>/dev/null || cat {} 2>/dev/null || tree -C {} 2>/dev/null'
+  --bind 'ctrl-/:change-preview-window(down|hidden|)'
+"
+
+# ALT-C: cd into selected directory
+export FZF_ALT_C_OPTS="
+  --preview 'tree -C {} | head -200'
+"
+
+# CTRL-R: Search history
+export FZF_CTRL_R_OPTS="
+  --preview 'echo {}'
+  --preview-window down:3:wrap
+  --bind 'ctrl-y:execute-silent(echo -n {2..} | cb)+abort'
+"
+
+# Completion trigger (default is **)
+export FZF_COMPLETION_TRIGGER='~~'
+
+# Enable fzf keybindings and completions
+# Debian/Ubuntu package locations
+if [[ -f /usr/share/doc/fzf/examples/key-bindings.zsh ]]; then
+  source /usr/share/doc/fzf/examples/key-bindings.zsh
+fi
+if [[ -f /usr/share/doc/fzf/examples/completion.zsh ]]; then
+  source /usr/share/doc/fzf/examples/completion.zsh
+fi
+
+# Homebrew locations (macOS)
+if [[ -f "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/key-bindings.zsh" ]]; then
+  source "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/key-bindings.zsh"
+fi
+if [[ -f "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/completion.zsh" ]]; then
+  source "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/fzf/shell/completion.zsh"
+fi
+
+# Git install location
+[[ -f ~/.fzf.zsh ]] && source ~/.fzf.zsh
+
+# ===== Enhanced FZF Functions =====
+
+# fzf git log - browse commits
+fgl() {
+  git log --graph --color=always \
+    --format="%C(auto)%h%d %s %C(black)%C(bold)%cr" "$@" |
+  fzf --ansi --no-sort --reverse --tiebreak=index \
+    --bind "ctrl-m:execute:
+      (grep -o '[a-f0-9]\{7\}' | head -1 |
+      xargs -I % sh -c 'git show --color=always % | less -R') << 'FZF-EOF'
+      {}
+FZF-EOF"
+}
+
+# fzf git branch - checkout branch
+fgb() {
+  local branches branch
+  branches=$(git branch --all | grep -v HEAD) &&
+  branch=$(echo "$branches" |
+           fzf -d $(( 2 + $(wc -l <<< "$branches") )) +m) &&
+  git checkout $(echo "$branch" | sed "s/.* //" | sed "s#remotes/[^/]*/##")
+}
+
+# fzf git stash - browse and apply stashes
+fgs() {
+  local stash
+  stash=$(git stash list | fzf --reverse -d: --preview 'git stash show --color=always -p {1}') &&
+  git stash apply $(echo "$stash" | cut -d: -f1)
+}
+
+# fzf man pages
+fman() {
+  man -k . | fzf --prompt='Man> ' --preview 'echo {} | awk "{print \$1}" | xargs man' | awk '{print $1}' | xargs man
+}
+
+# fzf npm scripts
+fnpm() {
+  local script
+  script=$(cat package.json | jq -r '.scripts | keys[]' | fzf --preview 'cat package.json | jq -r ".scripts.{}"')
+  [[ -n "$script" ]] && npm run "$script"
+}
+
+# Interactive cd with preview
+fcd() {
+  local dir
+  dir=$(find ${1:-.} -path '*/\.*' -prune -o -type d -print 2>/dev/null | fzf +m --preview 'tree -C {} | head -100') &&
+  cd "$dir"
+}
+
+# Edit file with fzf
+fe() {
+  local file
+  file=$(fzf --preview 'command -v bat &>/dev/null && bat -n --color=always {} || cat {}')
+  [[ -n "$file" ]] && ${EDITOR:-vim} "$file"
+}
+
+# Search and edit with ripgrep + fzf
+frg() {
+  local file line
+  read -r file line <<< $(rg --line-number --no-heading "$@" | fzf -d: --preview 'bat --color=always --highlight-line {2} {1}' | awk -F: '{print $1, $2}')
+  [[ -n "$file" ]] && ${EDITOR:-vim} "$file" +$line
+}


### PR DESCRIPTION
Syncs two portable dotfile tweaks made directly on bonbon back into the repo.

- **`modules/zsh/fzf.zsh`** (new): fzf options, fd integration, CTRL-T/ALT-C/CTRL-R previews, `~~` completion trigger, and key-binding/completion sourcing for both Debian (`/usr/share/doc/fzf`) and Homebrew layouts. Auto-loaded by the existing `$DOTFILES/**/*.zsh` glob in zshrc.
- **`modules/claude/hooks/experiment-log.sh`**: drop the Auto-stub fallback — when the summariser returns nothing (no API key / rate-limited) skip silently rather than emit low-value stub entries that had to be cleaned up by hand; state still advances so the turn isn't reprocessed.

Machine-local edits on bonbon (gitconfig identity/`safe.directory`, a `/home/d/.foundry/bin` PATH line) were intentionally left out — they belong in `~/.gitconfig.local` / per-machine config, not the shared repo.