### PR TITLE
fix(python): uv tool installs broke on Linux (apt flags injected)

### DIFF
--- a/modules/python/install.sh
+++ b/modules/python/install.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 . "$DOTFILES/scripts/core/main.sh"
 install::package "Python (3)" "python3"
 
@@ -9,13 +10,18 @@ else
   log::success "uv already installed"
 fi
 
-# UV tools (replaces pip3 install which fails with PEP 668)
-install::with "uv tool" "ruff" "ruff" ""
-install::with "uv tool" "ty" "ty" ""
-install::with "uv tool" "pip-audit" "pip-audit" ""
-install::with "uv tool" "ipython" "ipython" ""
-install::with "uv tool" "jupyter" "jupyter-core" ""
-install::with "uv tool" "pre-commit" "pre-commit" ""
+# uv installs itself + its tools into ~/.local/bin; ensure it's on PATH so the
+# tool installs below resolve `uv` during a fresh bootstrap (the curl installer
+# only edits shell rc files, not the live PATH).
+[[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && export PATH="$HOME/.local/bin:$PATH"
+
+# UV tools (replaces pip3 install which fails with PEP 668).
+install::uv_tool "ruff" "ruff"
+install::uv_tool "ty" "ty"
+install::uv_tool "pip-audit" "pip-audit"
+install::uv_tool "ipython" "ipython"
+install::uv_tool "jupyter" "jupyter" "jupyter-core"
+install::uv_tool "pre-commit" "pre-commit"
 
 if cmd_exists pre-commit; then
   mkdir -p "$HOME/.git-hooks"

--- a/scripts/core/install.sh
+++ b/scripts/core/install.sh
@@ -34,6 +34,24 @@ install::cask() {
   install::with "brew" "$1" "$2" "$3" "--cask"
 }
 
+# Install a CLI via `uv tool install` (idempotent). Do NOT route uv tools through
+# install::with: with an empty EXTRA it back-fills the system package-manager
+# flags (on Linux, apt's `--allow-unauthenticated -qqy`), which `uv tool install`
+# rejects — silently breaking ruff/ty/etc on Linux while working on macOS (brew's
+# args are empty). Args: readable name, command to probe, package (default name).
+install::uv_tool() {
+  local -r readable_name="$1"
+  local -r cmd="$2"
+  local -r pkg="${3:-$2}"
+  if platform::command_exists "$cmd"; then
+    log::success "$readable_name"
+  elif platform::command_exists uv; then
+    log::execute "uv tool install $pkg" "$readable_name"
+  else
+    log::warning "$readable_name: uv not on PATH; skipping uv tool install"
+  fi
+}
+
 # Install a developer CLI tool, preferring Homebrew (macOS always; Linux only
 # when Linuxbrew is present) and falling back to a prebuilt GitHub-release binary
 # only when brew is unavailable — e.g. a bare Linux box where the tool has no apt


### PR DESCRIPTION
`install::with` back-fills an empty EXTRA with the system package-manager flags, so on Linux every `install::with "uv tool" …` ran `uv tool install --allow-unauthenticated -qqy <pkg>` — which uv rejects. Result: **ruff/ty/pip-audit/ipython/jupyter/pre-commit silently never installed on Linux** (macOS unaffected; brew's args are empty).

Caught by the new gantry e2e suite: `dotfiles-dev`'s image build verify failed with `MISSING TOOL: ruff`.

Fix: add `install::uv_tool` (calls `uv tool install` directly, idempotent), ensure `~/.local/bin` is on PATH first, and use it in the python module. `shellcheck` clean.