### PR TITLE
fix(agents): repair cross-host skill/agent wiring

### DIFF
--- a/modules/agents/.gitignore
+++ b/modules/agents/.gitignore
@@ -1,2 +1,7 @@
 # Local settings may contain sensitive permissions
 settings.local.json
+
+# Machine-local skill links created by setup.sh from skills.local.conf
+/skills/cua-driver
+/skills/find-crop
+/skills/gog

--- a/modules/agents/setup.sh
+++ b/modules/agents/setup.sh
@@ -10,4 +10,20 @@
 # Ensure target directories exist (symlinks.conf populates them)
 mkdir -p ~/.agents ~/.claude ~/.pi/agent
 
+# Link machine-local skills (skills.local.conf) into skills/ when their
+# targets exist on this machine. Linked names are gitignored, so hosts
+# without a target stay clean instead of carrying broken symlinks.
+while read -r line || [[ -n "$line" ]]; do
+  [[ -z "$line" || "$line" == \#* ]] && continue
+  skill_name=${line%% -> *}
+  skill_target=${line#* -> }
+  skill_target=${skill_target/#\~/$HOME}
+  if [ -e "$skill_target" ]; then
+    ln -sfn "$skill_target" "$DOTFILES/modules/agents/skills/$skill_name"
+    log::success "linked local skill '$skill_name'"
+  else
+    log::warning "local skill '$skill_name' skipped ($skill_target not on this machine)"
+  fi
+done < "$DOTFILES/modules/agents/skills.local.conf"
+
 log::success "Shared agent config setup complete"

--- a/modules/agents/skills.local.conf
+++ b/modules/agents/skills.local.conf
@@ -1,0 +1,7 @@
+# Machine-local skills, linked into skills/ by setup.sh when the target
+# exists on this machine; absent targets are skipped with a warning.
+# Names listed here must also be in .gitignore so per-host links never
+# dirty the tree. Format matches symlinks.conf: <name> -> <target>.
+cua-driver -> /Applications/CuaDriver.app/Contents/Resources/Skills/cua-driver
+find-crop -> ~/projects/github.com/DJRHails/find-crop/skills/find-crop
+gog -> ~/projects/github.com/DJRHails/kb/agents/ava/skills/gog

--- a/modules/agents/skills/cua-driver
+++ b/modules/agents/skills/cua-driver
@@ -1,1 +1,0 @@
-/Applications/CuaDriver.app/Contents/Resources/Skills/cua-driver

--- a/modules/agents/skills/find-crop
+++ b/modules/agents/skills/find-crop
@@ -1,1 +1,0 @@
-/Users/dh/projects/github.com/DJRHails/find-crop/skills/find-crop

--- a/modules/agents/skills/gog
+++ b/modules/agents/skills/gog
@@ -1,1 +1,0 @@
-/Users/dh/projects/github.com/DJRHails/kb/agents/ava/skills/gog

--- a/modules/agents/skills/instrument-agent/SKILL.md
+++ b/modules/agents/skills/instrument-agent/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: instrument-agent
+description: Set up Raindrop AI traces for an agent and verify they flow into Workshop.
+when_to_use: Use when the user says "set up traces", "add tracing", "instrument my agent", "wire Raindrop", "Workshop is empty", or "make traces show up in Workshop." Guides unknown repos by discovering runtime and telemetry setup, using current Raindrop docs/package types, making the smallest safe change, and proving one useful Workshop run.
+---
+
+You are helping instrument an AI agent so its next meaningful run appears in Raindrop Workshop. Workshop is the local viewer; it does not run the agent. The user's agent app runs the workflow, the Raindrop SDK captures model/tool boundaries and context, and Workshop renders that telemetry as a debuggable run.
+
+Use supported Raindrop SDK/integration paths. Do not hand-wire Workshop ingestion endpoints or invent SDK APIs. If the repo's telemetry setup is too custom to instrument safely, stop with a clear handoff to the Raindrop docs or team.
+
+## Use Docs First
+
+Raindrop SDK and integration APIs move quickly. Before writing code, fetch docs in parallel: the docs index, the likely stack-specific page, and installed package README/types when available.
+
+- Docs index: `https://raindrop.ai/docs/llms.txt`
+- Introduction: `https://raindrop.ai/docs/introduction`
+- Integration overview: `https://raindrop.ai/docs/integrations/overview`
+- Core SDKs: `https://raindrop.ai/docs/sdk/typescript`, `/sdk/python`, `/sdk/rust`, `/sdk/go`, `/sdk/http-api`, `/sdk/browser`
+- Framework integrations: `https://raindrop.ai/docs/integrations/<name>` such as `vercel-ai-sdk`, `claude-agent-sdk`, `langchain`, `openai-agents`, `pydantic-ai`, `google-adk`, `bedrock`, `azure-openai`, `vertex-ai`
+
+Use this skill for the workflow and Workshop-specific judgment. Use the docs and installed package README/types for exact install commands, imports, options, and signatures.
+
+## Core Rules
+
+- Give visible progress. Say what phase you are in, what you learned, and what you are about to edit. Do not silently research for minutes.
+- Report often but briefly: one or two sentences per update, focused on current phase, finding, and next step. Avoid long dumps unless you are blocked and need a decision.
+- Before editing any file, tell the user about the intended change, and give them an honest assessment for how risky it might be.
+- Instrument one real agent entry point first. If several are plausible, ask which one should appear in Workshop.
+- First get a minimal useful run into Workshop, then enrich it. Do not trace every helper/tool/sub-agent before Phase 1 works.
+- Respect existing telemetry ownership. If the repo already initializes OpenTelemetry, Sentry, Datadog, Honeycomb, Traceloop, LangSmith, or another provider, do not create a competing provider.
+- Updating the matching Raindrop SDK/integration to the latest available version is mandatory before instrumentation edits. Do not proceed on an older installed SDK just because it is already present.
+- Prefer installed package docs/types over memory. If an API is not present in the installed package, do not use it.
+- Verification is required. Success means Workshop shows a useful run, not just that dependencies installed.
+
+## Mental Model
+
+One useful Workshop run should show:
+
+- the user/job input that triggered the agent,
+- the final output or error,
+- the main LLM call,
+- real tool executions and their results,
+- enough properties to recognize the customer/session/job being debugged.
+
+Most integrations use one of three shapes:
+
+- **Interaction boundary:** `begin` when one invocation starts, run the model/tool loop, then `finish` with output or error. Use this for Python, Rust, TypeScript core SDK, and custom loops.
+- **SDK wrapper:** wrap the agent/model SDK once and pass per-call metadata. Use this for Vercel AI SDK, Claude Agent SDK, and similar integrations.
+- **Existing OpenTelemetry owner:** attach Raindrop through the existing telemetry setup if supported. Do not create a second global tracer/provider.
+
+## Phase 0: Orient
+
+Do a quick read-only pass:
+
+- Find the target agent entry point: route, worker, CLI, queue job, MCP server, or agent class.
+- Identify language/runtime and model/agent SDK: Python, Rust, TypeScript, Vercel AI SDK, Claude Agent SDK, OpenAI/Anthropic direct SDK, LangChain, etc.
+- For Python, record `python --version`, package version, and the actual `raindrop.analytics` surface before assuming current docs apply.
+- Identify where tools actually execute.
+- Identify package manager and env file convention.
+- Search for existing telemetry: `opentelemetry`, `NodeSDK`, `TracerProvider`, `Sentry.init`, Datadog, Honeycomb, Traceloop, LangSmith, `RAINDROP_*`.
+- Check whether Workshop is running: `curl -fsS http://localhost:5899/health`.
+
+Timebox this phase. If discovery is not converging quickly, report what you know and ask the smallest concrete question.
+
+Ask only when the next edit would otherwise be a guess. Keep it concrete:
+
+- "I found `apps/api/src/chat.ts` and `workers/agent.ts`. Which should appear in Workshop first?"
+- "I found `src/sentry.ts` and `src/otel.ts`. Which telemetry initializer runs in this agent process?"
+- "What command runs one representative agent invocation locally?"
+
+## Phase 1: Basic Run Visibility
+
+Goal: prove the local trace path works with the smallest top-level instrumentation. A successful Phase 1 may show only a basic interaction summary in Workshop; it does not need complete LLM/tool span coverage.
+
+Make the smallest change:
+
+- Install or update the matching Raindrop SDK/integration to the latest available version using the repo's package manager, then inspect the installed README/types before coding.
+- Point the app at local Workshop, usually with `RAINDROP_LOCAL_DEBUGGER=http://localhost:5899/v1/`.
+- Add minimal instrumentation to one real entry point: wrapper call metadata, or `begin` before the invocation and `finish` after final output/error.
+- Run one representative invocation.
+- Verify a run appears in Workshop with enough input/output to prove the right code path is connected.
+
+Phase 1 troubleshooting:
+
+- If Workshop is empty, confirm the command exercised the instrumented entry point.
+- If the app ran but no run appears, confirm the app process received the local Workshop env/config.
+- If using a wrapper SDK, confirm the invoked code calls the wrapped client, not the original import.
+- If using `begin`/`finish`, confirm both run in the invoked path and flush/close happens before short-lived processes exit.
+- If existing telemetry is present, confirm you did not create a second competing provider.
+- If Workshop is not reachable, stop and say Workshop is down. Do not say "wired" or point the user at the Workshop URL as if verification succeeded.
+- If these checks do not reveal the problem, stop and report the exact evidence instead of adding more instrumentation.
+
+## Phase 2: Enrichment
+
+Goal: turn the Phase 1 run into a useful debugging trace.
+
+After Phase 1 works:
+
+- Add useful `properties`: tenant/org/workspace, request/job/session/conversation IDs, route/source/surface. Do not invent placeholders.
+- Ensure the LLM call is visible as an LLM span or obvious interaction summary.
+- Ensure real tool executions are visible as tool spans/events.
+- Preserve existing telemetry setup.
+- Add streaming/live events only when the SDK supports them and they help debugging.
+
+Phase 2 troubleshooting:
+
+- Thin Overview: fix interaction input/output and useful properties.
+- Missing LLM call: confirm the model call uses the wrapper or a supported span helper.
+- Missing tools: wrap the real tool body, not the model's tool-call decision.
+- Duplicate tools: check for both framework auto-instrumentation and manual wrapping on the same operation.
+
+## Choosing The Path
+
+Always consult docs first, then use the notes below to decide.
+
+### TypeScript Core SDK
+
+Docs: `https://raindrop.ai/docs/sdk/typescript`
+
+Hard version gate: require the latest available `raindrop-ai` package for TypeScript/JavaScript core SDK instrumentation, and never lower than `0.0.90`. If the repo has an older installed package, update first or stop and report the version mismatch.
+
+Use for custom TypeScript/Node agents and direct provider SDK calls. The core shape is:
+
+```ts
+const raindrop = new Raindrop({
+  writeKey: process.env.RAINDROP_WRITE_KEY,
+  endpoint: process.env.RAINDROP_ENDPOINT ?? process.env.RAINDROP_LOCAL_DEBUGGER,
+});
+
+const interaction = raindrop.begin({
+  eventId,
+  event: "agent_name",
+  userId,
+  input,
+  convoId,
+  properties,
+});
+
+try {
+  const output = await runAgentLoop();
+  interaction.finish({ output, model });
+} catch (err) {
+  interaction.finish({ output: `Error: ${err instanceof Error ? err.message : String(err)}` });
+  throw err;
+} finally {
+  await raindrop.flush();
+}
+```
+
+In Phase 2, use the current docs/package types for manual span/tool helpers and only wrap real execution boundaries.
+
+### Vercel AI SDK
+
+Docs: `https://raindrop.ai/docs/integrations/vercel-ai-sdk`
+
+Use `@raindrop-ai/ai-sdk`. This integration is designed to avoid manual OpenTelemetry setup. The docs cover:
+
+- `raindrop.wrap(ai, ...)`,
+- `eventMetadata(...)`,
+- AI SDK version differences,
+- native telemetry for AI SDK v7+,
+- tool call tracing,
+- flush/shutdown and debugging.
+
+Gotchas to keep inline:
+
+- `eventMetadata(...)` is call metadata, not a side effect.
+- Verify the invoked code calls the wrapped functions/client.
+- Do not choose native telemetry unless installed docs/types and AI SDK version support it.
+
+### Claude Agent SDK
+
+Docs: `https://raindrop.ai/docs/integrations/claude-agent-sdk`
+
+Use `@raindrop-ai/claude-agent-sdk`. The docs cover wrapping the Claude Agent SDK, passing `eventMetadata()` to tracked `query()` calls, auto tool tracing, subagent hierarchy, flush/shutdown, and debugging.
+
+Gotcha: calls without `eventMetadata()` may run normally but not be tracked by Raindrop, depending on the installed package behavior.
+
+### Python
+
+Docs: `https://raindrop.ai/docs/sdk/python`
+
+Use `raindrop-ai`. For Phase 1, prefer `raindrop.begin(...)` before the custom loop and `interaction.finish(...)` after final output/error. This proves Workshop connectivity without needing perfect tool spans.
+
+For Python custom loops:
+
+- Check Python and `raindrop-ai` versions first, then update `raindrop-ai` to the latest available version before editing instrumentation.
+- Do not use `track_ai` as a Workshop Phase 1 path. If the installed package only exposes `track_ai`, stop and report that this package version cannot produce a visible Workshop run with the current local ingestion behavior.
+- Phase 1: wrap the whole model/tool loop with `begin`/`finish`.
+- Phase 2: preserve loop behavior and add instrumentation at real boundaries: provider call and tool function execution.
+- Python tool/span helpers, decorators, manual spans, and auto-instrumentation may require tracing to remain enabled. Verify useful Workshop spans before promising tool-level coverage.
+- If the Python app already has a complex OTEL/Sentry setup, do not modify it unless you can follow a supported Raindrop SDK path.
+
+### Rust
+
+Docs: `https://raindrop.ai/docs/sdk/rust`
+
+Use the Rust `raindrop-ai` crate and the installed crate docs/API. The docs describe `Client::begin`, `Interaction::finish`, `Client::flush`/`close`, `track_ai`, manual spans, and tool spans.
+
+Keep guidance short:
+
+- Phase 1: wrap the whole async agent loop with `begin`/`finish`, then `flush` or `close`.
+- Phase 2: use documented Rust span/tool helpers only after the top-level run lands.
+- The Rust SDK is beta. Pin the crate/tag as the docs recommend and trust installed crate APIs.
+
+### Other Framework Integrations
+
+Docs index: `https://raindrop.ai/docs/llms.txt`
+
+For LangChain, OpenAI Agents SDK, Pydantic AI, Google ADK, Bedrock, Azure OpenAI, Vertex AI, CrewAI, Strands, and similar frameworks, prefer the matching integration docs over inventing generic wrappers.
+
+If no supported integration fits, stop gracefully:
+
+> I could not find a safe Raindrop SDK/integration path for this setup. Please consult the Raindrop docs or reach out to the Raindrop team with the agent entry point and telemetry setup files.
+
+## Existing OpenTelemetry / Sentry / Datadog
+
+This is the main case where the skill should add value beyond docs.
+
+If the app already owns telemetry:
+
+- Find the initializer that actually runs in the agent process.
+- Do not create a second `NodeSDK`, tracer provider, or equivalent global provider.
+- Look for a Raindrop-supported "external OpenTelemetry" shape in the installed package docs/types.
+- Some setups need only a Raindrop span processor. Others also need Raindrop instrumentations. Do not invent `instrumentModules`; use only what installed docs/types require.
+- After the smallest integration, run the agent once and verify Workshop before tuning modules/instrumentations.
+
+If you cannot identify the telemetry owner, ask for that file or stop with a handoff to docs/team.
+
+## Verification
+
+Use the strongest available check:
+
+- Raindrop MCP when available: inspect the current/latest run, outline, or trace query results.
+- HTTP/local API only if supported by the current Workshop docs or installed tooling.
+- UI: a visible run in Workshop.
+
+Confirm the run is useful:
+
+- Phase 1 success: one real invocation appears with input/output or a clear interaction summary.
+- Phase 2 success: expected LLM/tool activity is visible in Overview or span tree.
+
+If a run exists but content is not useful, verification failed. Keep diagnosing or stop with exact evidence.
+
+## Handoff
+
+Verified:
+
+> Wired. I ran the agent once and confirmed a useful Workshop run at http://localhost:5899.
+
+Needs user run:
+
+> Wired. Workshop is running at http://localhost:5899. Run `<command>` now; the next run should appear in Workshop. If it stays empty, we can debug further!
+
+Blocked:
+
+> I stopped before guessing. `<specific ambiguity/failure>`. The next step is `<specific user choice or docs/team handoff if nothing truly works (try your hardest before doing this. For Team handoff, report diagnostics, code skeleton without revealing too much about user's proprietary code)>`.

--- a/modules/agents/skills/setup-agent-replay/SKILL.md
+++ b/modules/agents/skills/setup-agent-replay/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: setup-agent-replay
+description: Set up a local agent replay server for Raindrop Workshop. Use when the user wants Workshop to replay a captured trace against their real local agent code and tools. Creates/updates `.raindrop/agents.yaml`, scaffolds a language-appropriate replay server, registers the project with `raindrop replay register`, and verifies `/health`.
+---
+
+You are running in the user's agent repository, not in Workshop.
+
+Your job is to make the agent replayable from Raindrop Workshop without the user manually starting a replay server.
+
+## Target Contract
+
+Workshop expects:
+
+- `.raindrop/agents.yaml` committed in the agent repo.
+- A replay server command in that yaml, plus `cwd` when the command must run from a subdirectory.
+- A replay server with:
+  - `GET /health`
+  - `POST /replay`
+- A local project registration via `raindrop replay register`.
+
+Replay server ports must be in `61020-61044`.
+
+Workshop runs on `http://localhost:5899`.
+
+If Raindrop MCP is not available or cannot reach Workshop, run:
+
+```bash
+raindrop workshop
+```
+
+Then retry the MCP/tool call. Do not stop just because the MCP server is unavailable.
+
+## If `.raindrop/agents.yaml` Already Exists
+
+Before changing anything, read `.raindrop/agents.yaml`.
+
+Ask the user whether to:
+
+1. Start/register the existing replay setup.
+2. Add a new agent replay entry.
+
+If they choose start/register:
+
+1. Run the configured command if needed.
+2. Verify `GET /health`.
+3. Run `raindrop replay register`.
+4. Stop. Do not scaffold a duplicate server.
+
+## Setup Steps
+
+### 1. Identify The Agent
+
+Find:
+
+- Event name used by tracing (`eventMetadata({ eventName: ... })`, equivalent SDK call, or current Workshop run).
+- Agent entry point to invoke.
+- Runtime context the agent requires, such as `orgId`, `orgPublicId`, `convoId`, `userId`, `source`.
+- Model defaults and obvious supported model overrides.
+- Existing script/package manager conventions.
+
+If the agent is not instrumented with Raindrop/Workshop tracing, stop and tell the user to instrument it first.
+
+### 2. Infer Input And Prefill
+
+Create:
+
+```yaml
+input:
+  orgPublicId: string
+  orgId: number
+
+prefillFromTrace:
+  orgPublicId: properties.orgPublicId
+  orgId: properties.orgId
+```
+
+`input` is the shape passed to the replay server as `request.context`.
+
+`prefillFromTrace` tells Workshop how to prefill that context from the selected trace. The user may edit the values in the UI before replay.
+
+Only include fields the agent actually needs to run.
+
+### 3. Pick A Port
+
+Pick the first unused port in `61020-61044`.
+
+Use that port as a constant in the generated replay server code:
+
+```typescript
+const PORT = 61020;
+```
+
+Do not put the port in `.raindrop/agents.yaml`.
+
+### 4. Generate The Replay Server
+
+Create the smallest server that fits the project language and conventions.
+
+Required `GET /health` response:
+
+```json
+{
+  "ok": true,
+  "eventName": "triage-agent-dev",
+  "port": 61020,
+  "cwd": "/absolute/path/to/project-or-subpackage",
+  "command": "pnpm replay-server",
+  "input": {
+    "orgPublicId": "string",
+    "orgId": "number"
+  },
+  "prefillFromTrace": {
+    "orgPublicId": "properties.orgPublicId",
+    "orgId": "properties.orgId"
+  },
+  "models": ["claude-sonnet-4-20250514", "gpt-4.1"]
+}
+```
+
+Required `POST /replay` request:
+
+```typescript
+interface ReplayRequest {
+  replayRunId: string;
+  sourceRunId?: string;
+  messages: Message[];
+  systemPrompt?: string;
+  userMessage?: string;
+  model?: string;
+  context: Record<string, unknown>;
+}
+```
+
+The server should keep the `POST /replay` request open until the replayed agent run finishes or fails. Workshop's `replay_run` MCP tool waits on this single request and surfaces its success or failure to the calling agent.
+
+Successful response:
+
+```json
+{ "replayId": "abc123", "status": "done" }
+```
+
+Failure response:
+
+```json
+{ "status": "error", "message": "Failed to create turn: ...", "stack": "..." }
+```
+
+Use a non-2xx HTTP response for request/agent failures when possible. A 200 response with `status: "error"` is also accepted and will be surfaced through the same MCP tool. Do not start the agent in a fire-and-forget async task that only logs errors after `POST /replay` has returned; Workshop cannot observe those failures.
+
+Replay should exercise the agent with as few side effects as possible. Before wiring the replay endpoint, inspect the agent's production entrypoint and extract the smallest reusable agent-running function you can. Prefer dependency injection, test doubles, dry-run flags, transaction rollback, or no-op adapters so replay avoids writes to the user's application database, billing systems, queues, email/SMS providers, analytics, or other external services. Preserve the real LLM/tool behavior needed for a faithful trace, but do not blindly call a production request handler if it persists application state as part of normal operation.
+
+Before invoking the agent, set:
+
+```typescript
+process.env.RAINDROP_LOCAL_DEBUGGER = "http://localhost:5899/v1/";
+```
+
+Do not pass `replayRunId` through an environment variable.
+
+Pass `request.context`, `request.messages`, `request.systemPrompt`, `request.userMessage`, and `request.model` into the agent in the way that matches the local codebase.
+
+For trace stitching, pass `request.replayRunId` through the SDK metadata surface:
+
+1. Prefer the SDK's event id field. Workshop uses this as the primary merge key.
+2. If the SDK cannot set an event id, add `replayRunId: request.replayRunId` to metadata properties.
+
+Make sure both the original run and the replay run have the same event name.
+
+Use the correct field name for the language:
+
+| SDK | Preferred stitch field |
+|---|---|
+| JS AI SDK | `eventMetadata({ eventId: request.replayRunId, ... })` |
+| JS Claude Agent SDK | `eventMetadata({ eventId: request.replayRunId, ... })` |
+| Python | `begin(event_id=request.replayRunId, ...)` / `Interaction(event_id=request.replayRunId, ...)` |
+| Go | `SpanOptions{EventID: request.replayRunId}` or an interaction started with that event id |
+| Rust | `SpanOptions { event_id: request.replayRunId, ... }` or an interaction started with that event id |
+
+etc. There are many more SDKs supported.
+
+Examples:
+
+```typescript
+// AI SDK
+experimental_telemetry: {
+  isEnabled: true,
+  metadata: eventMetadata({
+    eventId: request.replayRunId,
+    eventName: "<event-name>",
+    properties: {
+      ...request.context,
+    },
+  }),
+}
+
+// Claude Agent SDK
+eventMetadata({
+  userId: "<user-id>",
+  eventId: request.replayRunId,
+  eventName: "<event-name>",
+  properties: {
+    ...request.context,
+  },
+})
+```
+
+### 5. Standard Message Format
+
+Workshop sends AI SDK-style JSON:
+
+```typescript
+interface Message {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string | ContentPart[];
+  toolCalls?: ToolCall[];
+  toolCallId?: string;
+}
+```
+
+For TypeScript AI SDK agents, this usually passes through directly.
+
+For other SDKs or languages, generate the small adapter needed by that project.
+
+### 6. Write `.raindrop/agents.yaml`
+
+Example:
+
+```yaml
+triage-agent-dev:
+  # Optional. Relative paths are resolved from the project root that
+  # contains `.raindrop/agents.yaml`.
+  cwd: apps/dawn
+  command: pnpm replay-server
+
+  input:
+    orgPublicId: string
+    orgId: number
+
+  prefillFromTrace:
+    orgPublicId: properties.orgPublicId
+    orgId: properties.orgId
+
+  models:
+    - claude-sonnet-4-20250514
+    - gpt-4.1
+```
+
+If adding another agent, preserve existing entries.
+
+Use `cwd` for monorepos or nested apps when the replay command is only valid from a package directory. For example, prefer:
+
+```yaml
+triage-agent-dev:
+  cwd: apps/dawn
+  command: pnpm replay-server
+```
+
+over registering a command from the repository root that only works inside `apps/dawn`.
+
+### 7. Add Scripts
+
+Add the replay command using the project's normal conventions.
+
+Examples:
+
+- TypeScript: `pnpm replay-server`
+- Python: `python scripts/replay_server.py` or `poetry run python scripts/replay_server.py`
+- Go: `go run ./cmd/replay-server`
+- Rust: `cargo run --bin replay-server`
+
+If the project has a normal dev command, add or suggest a combined command (`dev:all`, `dev:replay`, `make dev`, etc.) when it is safe and idiomatic.
+
+### 8. Verify
+
+Start the replay server once.
+
+Check:
+
+```bash
+(cd <configured-cwd> && <configured-command>)
+curl -fsS http://127.0.0.1:<port>/health
+```
+
+Verify the response includes:
+
+- `ok: true`
+- `eventName`
+- `port`
+- `cwd`
+- `command`
+- `input`
+- `prefillFromTrace`
+
+### 9. Register
+
+Run from the project root:
+
+```bash
+raindrop replay register
+```
+
+Registration starts each configured command from its configured `cwd`, waits for `/health`, confirms the agent is reachable, and stores the last seen port. If registration fails, fix `.raindrop/agents.yaml` instead of continuing.
+
+Require a successful confirmation like:
+
+```text
+Registered replay project:
+  path: /path/to/project
+  config: /path/to/project/.raindrop/agents.yaml
+  agents:
+    - eventName: triage-agent-dev
+```
+
+If registration fails, stop and show the error. Do not claim replay is ready.
+
+### 10. Run A Test Replay
+
+Ask the user before running the final test replay.
+
+Default to replaying a past trace. Use the current Workshop run when available; otherwise ask the user to select a source run in Workshop or provide a run id. Do not invent a synthetic replay unless the user explicitly asks for one.
+
+Ask with a concrete default:
+
+> "Replay setup is registered. Should I run a test replay now using the selected/past Workshop trace?"
+
+If the user agrees, prefer the Raindrop MCP `replay_run` tool if it is available. If Raindrop MCP is unavailable, run `raindrop workshop`, then retry MCP. If MCP still is not available, trigger Workshop's replay API directly:
+
+```bash
+curl -N -fsS \
+  -H "Content-Type: application/json" \
+  -d '{"runId":"<source-run-id>"}' \
+  http://127.0.0.1:5899/api/replay
+```
+
+Verify all of the following:
+
+- Workshop auto-started or reached the replay server.
+- The replay server accepted `POST /replay`.
+- A replay run id was returned.
+- The replay emitted traces back to Workshop.
+- You can see the replay trace in Workshop, either by MCP/querying the run or by opening it in the UI.
+
+If the replay returns `missing_replay_agent` or says to run `/setup-agent-replay`, fix registration/startup and retry. If the replay server starts but no traces appear, fix `RAINDROP_LOCAL_DEBUGGER` and SDK metadata stitching before stopping.
+
+## Output
+
+When done, tell the user:
+
+- Which event name was registered.
+- Which port the replay server uses.
+- Which command Workshop will run.
+- That Workshop can now start the replay server automatically when Replay is clicked.
+- The replay run id from the test replay and how you verified its traces appeared.
+
+Do not introduce readonly mode, mocked tools, or mutating-tool classifications.

--- a/modules/claude/settings.ant.json
+++ b/modules/claude/settings.ant.json
@@ -44,7 +44,12 @@
     ],
     "defaultMode": "auto"
   },
+  "model": "claude-fable-5",
   "enableAllProjectMcpServers": false,
+  "skillOverrides": {
+    "code-review": "off",
+    "simplify": "off"
+  },
   "hooks": {
     "Notification": [
       {
@@ -99,10 +104,6 @@
   "enabledPlugins": {
     "swift-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true
-  },
-  "skillOverrides": {
-    "code-review": "off",
-    "simplify": "off"
   },
   "alwaysThinkingEnabled": true,
   "effortLevel": "xhigh",
@@ -174,6 +175,5 @@
       "**Classifier visibility**: The classifier sees user messages, CLAUDE.md, and prior tool CALLS (command strings, file paths, script bodies) — but NOT tool RESULTS (sbatch output, squeue output, echo output), and NOT runtime state (env vars, hostname, disk usage, process ownership). If a SOFT rule's applicability depends on something the user has stated in the transcript (e.g. 'I'm inside an srun shell', 'job 12345 is mine', 'that PID is mine'), treat that as user intent."
     ]
   },
-  "// NOTE": "This file goes in ~/.claude/settings.json (user-level), NOT .claude/settings.json in a repo. Auto-mode config is deliberately not read from project settings (a malicious repo could otherwise inject classifier rules). REPLACE <your-username> below with your actual cluster username before use — the classifier uses it to tell your own storage apart from other fellows'.",
-  "model": "claude-fable-5"
+  "// NOTE": "This file goes in ~/.claude/settings.json (user-level), NOT .claude/settings.json in a repo. Auto-mode config is deliberately not read from project settings (a malicious repo could otherwise inject classifier rules). REPLACE <your-username> below with your actual cluster username before use — the classifier uses it to tell your own storage apart from other fellows'."
 }


### PR DESCRIPTION
## Summary

Fixes the deployment wiring breakage left behind by the modules/claude → modules/agents migration, found during a full dotfiles audit.

- **Remove committed machine-specific symlinks** — `skills/{cua-driver,find-crop,gog}` pointed at `/Users/dh/...` and `/Applications/...`, broken on every host except the Mac.
- **Add `skills.local.conf` + setup.sh loop** — machine-local skills are now linked at setup time only when their target exists; link names are gitignored so other hosts stay clean. ⚠️ Re-run `./bootstrap.sh agents` on the Mac to recreate its three links.
- **Track `instrument-agent` and `setup-agent-replay`** — previously untracked in `~/.agents/skills`, which blocked `symlinks.conf` from linking that directory.
- **Commit harness key reorder in `settings.ant.json`** — no semantic change; stops perpetual dirty-tree drift.

## Deployed alongside (host-side, not in this diff)

Re-applied both `symlinks.conf` files via `scripts/link.sh`: repaired dangling `~/.claude/{CLAUDE.md,commands,skills}` (pointed at deleted modules/claude paths since ~Mar 4), which also fixes the `~/.claude-ant/commands` chain; created missing `~/.agents/{AGENTS.md,commands,settings.json,mcp.json}`, `~/.claude/agents`, and `~/.pi/agent/AGENTS.md`.

## Verification

- `shellcheck -S warning modules/agents/setup.sh` — clean
- `find ~/.claude ~/.claude-ant ~/.agents ~/.pi -xtype l` — no dangling links remain
- Live session skill list refreshed and now includes the two adopted Raindrop skills; `~/.claude-ant/commands` resolves to repo commands
- Worktree clean after setup run (gitignore covers per-host links)