### PR TITLE
fix(claude): drop dead agent-session-bridge hooks

### DIFF
--- a/modules/claude/settings.json
+++ b/modules/claude/settings.json
@@ -85,27 +85,10 @@
         ]
       }
     ],
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ ! -e /Users/dh/.agent-session-bridge/runtime/packages/claude-code/dist/claude-code/src/hook-cli.js ] || node /Users/dh/.agent-session-bridge/runtime/packages/claude-code/dist/claude-code/src/hook-cli.js session-start",
-            "async": true
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "matcher": "",
         "hooks": [
-          {
-            "type": "command",
-            "command": "[ ! -e /Users/dh/.agent-session-bridge/runtime/packages/claude-code/dist/claude-code/src/hook-cli.js ] || node /Users/dh/.agent-session-bridge/runtime/packages/claude-code/dist/claude-code/src/hook-cli.js stop",
-            "async": true
-          },
           {
             "type": "command",
             "command": "bash ~/.files/modules/claude/hooks/experiment-log.sh"


### PR DESCRIPTION
The SessionStart/Stop hooks invoke `~/.agent-session-bridge/runtime/.../hook-cli.js`, which no longer exists on the Mac and never existed in Linux worker containers — every gantry worker session start logged a `MODULE_NOT_FOUND` hook error (seen live in [tranquil-sleek-fern](https://gantry.hails.info/run/tranquil-sleek-fern)). Drop them outright rather than guard on existence; the `experiment-log.sh` Stop hook stays.

(Originally also made `core.hooksPath` portable, but main got there first — the regenerated gitconfig now documents that machine-specific paths like `core.hooksPath` belong in `~/.gitconfig.local`.)

Merging advances dotfiles HEAD → gantry's `rebuildProbe` rebuilds worker images on next spawn, removing the hook error from worker traces.