### PR TITLE
fix(python): set init.templateDir so pre-commit hooks install in new repos

### DIFF
--- a/modules/python/install.sh
+++ b/modules/python/install.sh
@@ -28,5 +28,16 @@ install::uv_tool "pre-commit" "pre-commit"
 if cmd_exists pre-commit; then
   mkdir -p "$HOME/.git-hooks"
   pre-commit init-templatedir "$HOME/.git-hooks" >/dev/null
-  log::success "pre-commit templatedir initialised at ~/.git-hooks"
+  # init-templatedir only populates the directory — git must also be pointed at
+  # it via init.templateDir, or new clones silently get no hooks. That setting
+  # is machine-local, so it lives in gitconfig.local (see modules/git/gitconfig),
+  # which the git module generates before this script runs.
+  if [ -f "$HOME/.gitconfig.local" ]; then
+    # shellcheck disable=SC2088 # literal ~ is intentional: git expands it, keeps the entry host-portable
+    git config --file "$HOME/.gitconfig.local" init.templateDir '~/.git-hooks'
+    log::success "pre-commit templatedir initialised at ~/.git-hooks"
+  else
+    # shellcheck disable=SC2088 # ~ is display text in a log message, not a path to expand
+    log::warning "~/.gitconfig.local missing — run the git module, then set init.templateDir=~/.git-hooks"
+  fi
 fi


### PR DESCRIPTION
## Problem

`modules/python/install.sh` ran `pre-commit init-templatedir ~/.git-hooks >/dev/null`. That command **only populates the template directory** — its warning that you must also set `init.templateDir` was piped to `/dev/null`, so the config was never written. Result: `git init` / `git clone` on a fresh machine produced repos with **no hooks at all** (verified empirically with a scratch repo).

## Fix

After `init-templatedir`, write `init.templateDir = ~/.git-hooks` into `~/.gitconfig.local` (the file `modules/git/gitconfig` designates for machine-local path settings), via `git config --file`. Guarded with a warning if that file doesn't exist yet, so a standalone python-module run on a virgin machine can't pre-create it and suppress the git module's identity prompt.

Literal `~` in the value is intentional — git expands path-type values, which keeps the entry host-portable (justified `shellcheck` ignores added).

## Verification

- **End-to-end:** plain `git init` before fix → no hooks; after fix → pre-commit shim installed automatically.
- **Hook behaviour:** commit with no `.pre-commit-config.yaml` passes (`--skip-on-missing-config`); a failing local hook blocks the commit; clean tree commits fine.
- **Lint:** `shellcheck -x` and `shfmt -i 2 -d` clean; new block run twice standalone → idempotent (single `templateDir` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)