### PR TITLE
fix(git): don't write empty credential.helper on Linux

### DIFF
--- a/modules/git/gitconfig.local.tmpl
+++ b/modules/git/gitconfig.local.tmpl
@@ -1,5 +1,3 @@
 [user]
 	name = AUTHORNAME
 	email = AUTHOREMAIL
-[credential]
-	helper = GIT_CREDENTIAL_HELPER

--- a/modules/git/setup.sh
+++ b/modules/git/setup.sh
@@ -14,8 +14,16 @@ setup_gitconfig () {
 
     sed -e "s/AUTHORNAME/$GIT_AUTHOR_NAME/g" \
       -e "s/AUTHOREMAIL/$GIT_AUTHOR_EMAIL/g" \
-      -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" \
       $local_git_config.tmpl > $local_git_config
+
+    # Only record a credential helper when one was actually chosen. An empty
+    # `helper =` line would reset git's accumulated helper list (gitconfig.local
+    # is included last), wiping e.g. gh's helper on Linux where git_credential
+    # is unset.
+    if [ -n "${git_credential:-}" ]
+    then
+      git config --file "$local_git_config" credential.helper "$git_credential"
+    fi
 
     log::success "generated $local_git_config"
   else


### PR DESCRIPTION
## Problem

`setup_gitconfig` (`modules/git/setup.sh`) substituted `$git_credential` into the `gitconfig.local` template's `[credential] helper =` line via `sed`. On **Linux**, `git_credential` is unset — the `osxkeychain` assignment is macOS-only and the `cache` default is commented out — so the rendered `gitconfig.local` got:

```ini
[credential]
	helper =
```

Because `gitconfig.local` is `include`d **last**, that empty value **resets git's accumulated multi-valued `credential.helper` list**, wiping `credential.https://github.com.helper = !gh auth git-credential`. HTTPS pushes then fail with `could not read Username for 'https://github.com'`.

(Spotted while fixing the pre-commit `init.templateDir` bug in #20.)

## Fix

- Drop the `[credential]` block from `gitconfig.local.tmpl`.
- In `setup_gitconfig`, only record a helper — via `git config --file` — when one was actually chosen (`[ -n "$git_credential" ]`). No helper chosen ⇒ no `[credential]` block written ⇒ the inherited helper list is left intact.

This mirrors the `git config --file` approach used for `init.templateDir` in #20.

## Verification

Ran both rendered paths in isolation against the real template:

- **Linux** (`git_credential=""`): output contains **no** `[credential]` block; `git config --get-all credential.helper` on it returns nothing → inherited list survives. ✓
- **macOS** (`git_credential=osxkeychain`): output contains `[credential] helper = osxkeychain`; resolves correctly. ✓

`shellcheck -x modules/git/setup.sh` clean. Change kept minimal and consistent with the file's existing `if … / then` style (no whole-file `shfmt` reflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)