### PR TITLE
feat(agents): default reusable loops (hygiene, doc-critic, perf-bestofn)

### DIFF
--- a/modules/agents/loops/README.md
+++ b/modules/agents/loops/README.md
@@ -1,0 +1,46 @@
+# Default loops
+
+Reusable, **project-agnostic** loop definitions, shared across coding agents the
+same way `subagents/` and `skills/` are (`symlinks.conf` links this dir into
+`~/.agents/loops`, `~/.claude/loops`, `~/.claude-ant/loops`). Because worker
+images bake the dotfiles, every worker has these at a known path — so a scheduled
+loop can reference a default loop here without the target repo carrying its own.
+
+## What a loop is
+
+A loop is a **single, self-contained iteration prompt**: one file that tells an
+agent how to do one bounded pass over a repo — read state first (so iterations
+don't repeat work), do exactly one improvement, write state back (log + commit +
+push). A scheduler (cron, the portcullis loop scheduler, or `/loop`) runs the
+file on an interval; the file is the whole contract, so editing the loop is
+editing one file.
+
+## Using a default loop
+
+- **As-is:** point a schedule at `~/.agents/loops/<name>.md` (e.g. `hygiene` works
+  in any repo). The worker reads it and runs one iteration in whatever repo it's
+  checked out in.
+- **Specialised:** copy it into a repo's `docs/loops/<name>.md` and tailor it.
+  Project-specific loops (tied to a particular dataset, research doc, or harness)
+  live in the repo, not here — only genuinely generic loops belong in dotfiles.
+
+## Shared conventions (every loop)
+
+1. **State first** — read the repo's loop ledger (`rg '\[<name>\]'` in the
+   experiment/change log) so the iteration continues rather than repeats.
+2. **One improvement** — pick the single highest-value item and finish it (code,
+   test, doc); don't start a second.
+3. **Write state back** — record the iteration in the repo's log if it has one
+   (`EXPERIMENT_LOG.md`, `CHANGELOG.md`, else a `[<name>]` line in a
+   `docs/loop-log.md`), then commit small and push. Other loops push concurrently,
+   so `git pull --rebase` immediately before pushing.
+4. **Guardrails** — never weaken a test or delete a cache to make a check pass;
+   smoke-test before any long run; respect the repo's own AGENTS.md/CLAUDE.md.
+
+## The defaults here
+
+- **`hygiene`** — toolchain/format/test/stale-artifact sweep; fix the worst finding.
+- **`doc-critic`** — audit the repo's docs/README against the code; fix the
+  highest-value inaccuracy or gap.
+- **`perf-bestofn`** — measure the top bottleneck, race N candidate fixes in
+  isolation, merge the winner.

--- a/modules/agents/loops/doc-critic.md
+++ b/modules/agents/loops/doc-critic.md
@@ -1,0 +1,41 @@
+# Loop: doc-critic
+
+Project-agnostic documentation-accuracy loop (suggested cadence: every 2–4 h, or
+after a feature lands). One iteration: audit the repo's docs against the code as a
+skeptical newcomer, then fix the single highest-value inaccuracy or gap. Default
+loop — works in any repo.
+
+## State first
+
+`rg '\[doc-critic\]'` the repo's log. The docs touched by commits since the last
+iteration are the priority surface; the rest is opportunistic.
+
+## Audit (cheap checks first)
+
+Re-read the README and the primary docs (the living/design docs, setup guide,
+API reference) as someone who just cloned the repo:
+
+- **Reproducibility.** Do the setup/build/test commands in the README actually
+  work on a clean checkout? Run them. A command that no longer exists, a renamed
+  script, a missing prerequisite is a finding.
+- **Code/doc agreement.** Claims about behaviour, flags, file paths, or
+  architecture that the code contradicts. Spot-check the load-bearing ones against
+  the source — don't trust the prose.
+- **Drift.** Features in recent commits that no doc mentions; docs describing
+  removed/changed behaviour; dead links and stale references.
+- **Calibration** (if the repo keeps a results/research doc): claims without the
+  evidence or hedging the repo's own conventions require.
+
+## Act
+
+Fix the single highest-value finding completely — a wrong setup command (blocks
+every newcomer) beats a stale claim beats a dead link. Edit the code's
+self-documentation only to state constraints, not to narrate. If a doc claim is
+unverifiable, mark it as such rather than deleting it. If everything reads
+accurate, say which docs are now trusted and at what depth.
+
+## Write state back
+
+Append a `[doc-critic]` entry to the repo's log: what was audited, the finding
+fixed (or "accurate"), the next-highest item. Commit + push (`git pull --rebase`
+before pushing — loops push concurrently). End with a ≤4-line status.

--- a/modules/agents/loops/hygiene.md
+++ b/modules/agents/loops/hygiene.md
@@ -1,0 +1,43 @@
+# Loop: hygiene
+
+Project-agnostic repo hygiene sweep (suggested cadence: every 4–6 h, or after a
+push to the default branch). One iteration: sweep, then fix the single worst
+finding. Default loop — works in any repo; reads the toolchain from the repo.
+
+## State first
+
+`rg '\[hygiene\]'` the repo's log (`EXPERIMENT_LOG.md` / `CHANGELOG.md` /
+`docs/loop-log.md`). Anything found/fixed/deferred there is off the table unless
+it's still the highest-value item.
+
+## Sweep (read-only, in order)
+
+1. **Toolchain green.** Detect the stack and run its linter, formatter (check
+   mode), type checker, and tests — e.g. Python `ruff check` / `ruff format
+   --check` / `ty check` (or mypy) / `pytest -q`; Node `oxlint` (or eslint) /
+   `tsc --noEmit` / `vitest run`; Rust `cargo clippy -- -D warnings` / `cargo fmt
+   --check` / `cargo test`. A first-run red that's just missing dev deps → install
+   them and note it, don't count it as a finding. Any real warning is a finding
+   (zero-warnings policy).
+2. **Untracked rot.** `git status --short` — untracked files older than a day get
+   committed, folded into a tracked doc, or trashed. `*.local.json` / local
+   settings must be gitignored.
+3. **Stale generated artifacts.** Figures/build outputs whose generating script
+   changed since the artifact was last committed — regenerate only when the change
+   plausibly altered output.
+4. **TODO/doc drift.** Checkboxes or docs contradicted by recent commits (done but
+   unchecked, or checked but reverted).
+5. **Worktrees.** List any `.git`/worktrees; flag merged/abandoned ones.
+
+## Act
+
+Fix the single worst finding completely (a red test beats a stale artifact beats
+TODO drift). Defer the rest by listing them in the log entry. Never "fix" by
+deleting a cache, weakening a test, or adding an ignore without a justification
+comment.
+
+## Write state back
+
+Append a `[hygiene]` entry to the repo's log **only if something was found/fixed**
+(no empty heartbeat entries). Commit + push (`git pull --rebase` before pushing —
+loops push concurrently). End with a ≤3-line status.

--- a/modules/agents/loops/perf-bestofn.md
+++ b/modules/agents/loops/perf-bestofn.md
@@ -1,0 +1,44 @@
+# Loop: perf-bestofn
+
+Project-agnostic best-of-N performance loop (suggested cadence: every 2–4 h, or
+on demand after a slow run). One iteration = one measured bottleneck → N
+independent candidate fixes raced in isolation → benchmark all → merge only the
+winner. Never ship an unmeasured optimisation. Default loop — works in any repo.
+
+## State first
+
+`rg '\[perf-bestofn\]'` the repo's log — bottlenecks already attacked (won or
+written off) are off the table unless new evidence reopens them.
+
+## Find the bottleneck (measure, don't guess)
+
+Profile or mine timings (test runtimes, build logs, a representative workload) for
+the single biggest wall-clock sink in a hot path. Classify it before touching
+code: CPU/algorithmic, IO/serialisation, network/IO-bound, or
+cache/recompute-bound. State the metric you'll move (wall-clock on a fixed
+workload, throughput, allocations) and how you'll measure it. If nothing is worth
+attacking (best candidate <10% of the workload), log that and stop — don't invent
+work.
+
+## Generate N candidates in parallel
+
+Spawn ~3 isolated attempts (worktrees / branches), same bottleneck brief, a
+**different tack each** (better algorithm/data structure vs caching/memoisation vs
+batching/parallelism vs avoiding the work). One tack per attempt; each must:
+implement it, run the agreed benchmark ≥3× (fixed input, stated warm/cold state),
+and confirm outputs are unchanged (tests pass, results identical to baseline).
+
+## Pick the winner
+
+Baseline-benchmark first with the same command. A candidate qualifies only if
+tests pass, outputs match, and the gain exceeds noise (≥10% or clearly outside
+run-to-run spread). Rank qualifiers by measured gain minus any added complexity /
+cache-invalidation cost; tie-break by smaller diff. Merge the winner; discard the
+rest (keeping any reusable idea in the log).
+
+## Write state back
+
+Append a `[perf-bestofn]` entry to the repo's log: bottleneck, the N tacks, a
+benchmark table (baseline + each candidate), winner and why, losers' ideas worth
+keeping. Commit + push (`git pull --rebase` before pushing — loops push
+concurrently). End with a ≤5-line status.

--- a/modules/agents/symlinks.conf
+++ b/modules/agents/symlinks.conf
@@ -10,3 +10,6 @@ commands -> ~/.claude/commands
 commands -> ~/.claude-ant/commands
 subagents -> ~/.claude/agents
 subagents -> ~/.claude-ant/agents
+loops -> ~/.agents/loops
+loops -> ~/.claude/loops
+loops -> ~/.claude-ant/loops


### PR DESCRIPTION
Project-agnostic loop iteration prompts under `modules/agents/loops/`, shared the same way `subagents/` and `skills/` are — `symlinks.conf` links them into `~/.agents/loops`, `~/.claude/loops`, `~/.claude-ant/loops`. Because worker images bake the dotfiles, every worker gets these at a known path, so a scheduled loop can point at a default without the target repo carrying its own. Project-specific loops (tied to a dataset/research-doc/harness) still live in the repo's `docs/loops/`.

Three generics to start: **hygiene** (toolchain/format/test/stale-artifact sweep), **doc-critic** (audit docs against the code), **perf-bestofn** (measure the bottleneck, race N isolated candidates, merge the winner). Each follows the shared loop contract (state-first via a `[name]` ledger, one improvement, write-back + pull-rebase before push).