### PR TITLE
feat(loops): always open a PR; the loop judges whether to merge

### DIFF
--- a/modules/agents/loops/README.md
+++ b/modules/agents/loops/README.md
@@ -31,9 +31,13 @@ editing one file.
 2. **One improvement** — pick the single highest-value item and finish it (code,
    test, doc); don't start a second.
 3. **Write state back** — record the iteration in the repo's log if it has one
-   (`EXPERIMENT_LOG.md`, `CHANGELOG.md`, else a `[<name>]` line in a
-   `docs/loop-log.md`), then commit small and push. Other loops push concurrently,
-   so `git pull --rebase` immediately before pushing.
+   (`EXPERIMENT_LOG.md`, `CHANGELOG.md`, else a `[<name>]` line in a `docs/loop-log.md`),
+   commit small, and **always open a PR** — never push straight to `main`, even on a solo
+   repo. Then use your judgement on whether to merge it: squash-merge a clean, low-risk,
+   well-tested change you're confident in; leave anything uncertain or worth a human glance
+   open for review. `git pull --rebase` before pushing the branch (loops run concurrently).
+   Also report findings to the loop's Slack channel — the scheduler's wrapper names it and
+   posts a start-ping there.
 4. **Guardrails** — never weaken a test or delete a cache to make a check pass;
    smoke-test before any long run; respect the repo's own AGENTS.md/CLAUDE.md.
 

--- a/modules/agents/loops/doc-critic.md
+++ b/modules/agents/loops/doc-critic.md
@@ -37,5 +37,8 @@ accurate, say which docs are now trusted and at what depth.
 ## Write state back
 
 Append a `[doc-critic]` entry to the repo's log: what was audited, the finding
-fixed (or "accurate"), the next-highest item. Commit + push (`git pull --rebase`
-before pushing — loops push concurrently). End with a ≤4-line status.
+fixed (or "accurate"), the next-highest item. Always **open a PR** (never push straight to
+`main`, even on a solo repo); then use your judgement on whether to merge it — squash-merge a
+clean, low-risk, well-tested change you're confident in, and leave anything uncertain or worth
+a human glance open. `git pull --rebase` before pushing the branch (loops run concurrently).
+End with a ≤4-line status.

--- a/modules/agents/loops/hygiene.md
+++ b/modules/agents/loops/hygiene.md
@@ -39,5 +39,4 @@ comment.
 ## Write state back
 
 Append a `[hygiene]` entry to the repo's log **only if something was found/fixed**
-(no empty heartbeat entries). Commit + push (`git pull --rebase` before pushing —
-loops push concurrently). End with a ≤3-line status.
+(no empty heartbeat entries). Always **open a PR** (never push straight to `main`, even on a solo repo); then use your judgement on whether to merge it — squash-merge a clean, low-risk, well-tested change you're confident in, and leave anything uncertain or worth a human glance open. `git pull --rebase` before pushing the branch (loops run concurrently). End with a ≤3-line status.

--- a/modules/agents/loops/perf-bestofn.md
+++ b/modules/agents/loops/perf-bestofn.md
@@ -40,5 +40,4 @@ rest (keeping any reusable idea in the log).
 
 Append a `[perf-bestofn]` entry to the repo's log: bottleneck, the N tacks, a
 benchmark table (baseline + each candidate), winner and why, losers' ideas worth
-keeping. Commit + push (`git pull --rebase` before pushing — loops push
-concurrently). End with a ≤5-line status.
+keeping. Always **open a PR** (never push straight to `main`, even on a solo repo); then use your judgement on whether to merge it — squash-merge a clean, low-risk, well-tested change you're confident in, and leave anything uncertain or worth a human glance open. `git pull --rebase` before pushing the branch (loops run concurrently). End with a ≤5-line status.


### PR DESCRIPTION
Loops can run on any repo now. Per the policy: **always open a PR** (never push straight to `main`, even on a solo repo), and the loop uses its **judgement on whether to merge** — squash-merge a clean, low-risk, well-tested change; leave anything uncertain open for review. Safe for auto-deploy repos (gantry). Updated hygiene/doc-critic/perf-bestofn + the README convention.