### PR TITLE
docs(agents): keep encrypted-file contents out of plaintext git metadata

### DIFF
--- a/modules/agents/AGENTS.md
+++ b/modules/agents/AGENTS.md
@@ -259,6 +259,7 @@ token budget.
 ## Git Hygiene
 
 - **Always gitignore `.agents/settings.local.json`** (and `.claude/settings.local.json`) - If you see these files in `git status` or `git diff`, add them to `.gitignore` before committing. These files contain local permissions and should never be tracked.
+- **Encrypted-at-rest files → keep their contents out of plaintext git metadata.** Some repos encrypt sensitive files at rest (transcrypt: `filter=crypt` in `.gitattributes`; verify a specific path with `git check-attr filter -- <file>`). The committed blob and the diff are ciphertext, so committing the *change* is safe — but the commit message, PR title/description, issue text, and review comments are all plaintext (and public if the repo is — assume public unless you've confirmed otherwise). Before writing any of those for a change that touches an encrypted file, check whether it's encrypted, then keep the public-facing text generic: never name the secrets, credentials, internal hostnames, service/workspace names, or architecture details that the encryption exists to hide. Put the real rationale in a comment *inside* the encrypted file, where it's protected. If you've already pushed something leaky, amend + force-push and re-edit the PR/issue text before merging.
 
 ## MCP Servers (mcporter)
 


### PR DESCRIPTION
Adds a **Git Hygiene** rule to the global agent standards.

Encrypted-at-rest files (e.g. transcrypt `filter=crypt`) ship as ciphertext in the blob and diff, so committing the change is safe — but commit messages, PR titles/descriptions, issue text, and review comments are plaintext (public on a public repo). The rule: before writing that metadata for a change touching an encrypted file, check `git check-attr filter -- <file>` and keep the public-facing text generic; put the real rationale in a comment inside the encrypted file.

Prompted by a slack-skill fix where the (encrypted) code was safe but the PR/commit text named private specifics.