### PR TITLE
fix(python): write absolute init.templateDir so prek can use it

### DIFF
--- a/modules/python/install.sh
+++ b/modules/python/install.sh
@@ -33,9 +33,13 @@ if cmd_exists pre-commit; then
   # is machine-local, so it lives in gitconfig.local (see modules/git/gitconfig),
   # which the git module generates before this script runs.
   if [ -f "$HOME/.gitconfig.local" ]; then
-    # shellcheck disable=SC2088 # literal ~ is intentional: git expands it, keeps the entry host-portable
-    git config --file "$HOME/.gitconfig.local" init.templateDir '~/.git-hooks'
-    log::success "pre-commit templatedir initialised at ~/.git-hooks"
+    # Write the EXPANDED absolute path, not a literal '~/.git-hooks'. git expands ~
+    # in init.templateDir, but prek (the pre-commit drop-in our repos run) does NOT
+    # — a literal tilde makes `prek init-templatedir` die `os error 2` seeding the
+    # bogus path. .gitconfig.local is machine-local (regenerated per host here), so
+    # an absolute path is correct and keeps both git and prek happy.
+    git config --file "$HOME/.gitconfig.local" init.templateDir "$HOME/.git-hooks"
+    log::success "pre-commit templatedir initialised at $HOME/.git-hooks"
   else
     # shellcheck disable=SC2088 # ~ is display text in a log message, not a path to expand
     log::warning "~/.gitconfig.local missing — run the git module, then set init.templateDir=~/.git-hooks"


### PR DESCRIPTION
## Problem
`modules/python/install.sh` wrote a **literal** `'~/.git-hooks'` into `~/.gitconfig.local`. git expands `~` in `init.templateDir`, but **prek** (the pre-commit drop-in our repos run) does **not** — so `prek init-templatedir` dies `os error 2` seeding the bogus path.

This was the root cause of a **fleet-wide gantry build outage**: every worker devcontainer rebuild failed at the prek step (Step 23, `devcontainer build failed (exit 1)`). Gantry has a workaround (DJRHails/gantry#287 rewrites the value in the build), but this fixes it at the source for every consumer.

## Fix
Write the **expanded absolute** `$HOME/.git-hooks`. `.gitconfig.local` is machine-local (regenerated per host by this script), so an absolute path is correct and works for both git and prek.

Verified against the real worker image: `init.templateDir` `~/.git-hooks` (prek RC 2) → `/home/dev/.git-hooks` (prek RC 0).