### PR TITLE
feat(claude): add claude::resume; session-search emits it

### DIFF
--- a/modules/agents/skills/session-search/SKILL.md
+++ b/modules/agents/skills/session-search/SKILL.md
@@ -48,7 +48,7 @@ python3 ~/.claude/skills/session-search/scripts/search.py "deploy" --context 400
 
 For each matching session the script prints:
 
-- **Session ID** and resume command (`claude --resume <id>`)
+- **Session ID** and resume command (`claude::resume <id>` — cd's into the session's original directory and resumes via the owning config profile; defined in `modules/claude/aliases.zsh`)
 - **Date**, **project**, and the **original prompt**
 - Up to 3 **matching snippets** with role labels and line numbers
 

--- a/modules/agents/skills/session-search/scripts/search.py
+++ b/modules/agents/skills/session-search/scripts/search.py
@@ -464,7 +464,7 @@ def format_timestamp(ts_ms: int) -> str:
 def _format_location(result: SearchResult) -> str:
     if result.source in (SessionSource.PI, SessionSource.PI_ARTIFACT):
         return f"File:     {result.path}"
-    return f"Resume:   claude --resume {result.session_id}"
+    return f"Resume:   claude::resume {result.session_id}"
 
 
 def _format_snippet(m: MatchSnippet) -> str:

--- a/modules/claude/aliases.zsh
+++ b/modules/claude/aliases.zsh
@@ -61,6 +61,38 @@ claude::ant() {
     claude "$@"
 }
 
+# Resume a session by id, cd-ing into its original directory first. Claude can
+# only --resume a session from the cwd it was started in, and session-search
+# only prints the bare `claude --resume <id>`. This resolves both the directory
+# and the owning config profile so a copy-pasted id Just Works.
+claude::resume() {
+  emulate -L zsh
+  local id=$1
+  [[ -n $id ]] || { echo "claude::resume: usage: claude::resume <session-id>" >&2; return 1; }
+
+  # Search every config-dir variant (default + ant) and the legacy agents dir.
+  local file
+  file=$(command find "$HOME/.claude" "$HOME/.claude-ant" "$HOME/.agents" \
+           -type f -name "${id}.jsonl" -print 2>/dev/null | head -1)
+  [[ -n $file ]] || { echo "claude::resume: no session '$id' under ~/.claude*, ~/.agents" >&2; return 1; }
+
+  # The encoded project dir is lossy ('/' and '.' both collapse to '-'), so read
+  # the real working directory from the transcript's cwd field instead.
+  local dir
+  dir=$(command grep -m1 -o '"cwd":"[^"]*"' "$file" | cut -d'"' -f4)
+  [[ -n $dir && -d $dir ]] || { echo "claude::resume: cannot resolve cwd for '$id' ($file)" >&2; return 1; }
+
+  cd "$dir" || return 1
+
+  # Route through the profile whose config dir owns the session so --resume finds
+  # it (and the ant profile gets its env + self-healing links).
+  case ${file%%/projects/*} in
+    "$HOME/.claude-ant") claude::ant --resume "$id" ;;
+    "$HOME/.claude")     claude --resume "$id" ;;
+    *)                   CLAUDE_CONFIG_DIR=${file%%/projects/*} claude --resume "$id" ;;
+  esac
+}
+
 claude::local() {
   ANTHROPIC_BASE_URL=http://localhost:1234 \
   ANTHROPIC_AUTH_TOKEN=lmstudio \


### PR DESCRIPTION
`claude::resume <id>` locates a session transcript across config-dir variants (`.claude` / `.claude-ant` / `.agents`), reads the real `cwd` from the transcript (the encoded project-dir name is lossy — both `/` and `.` collapse to `-`), `cd`s there, and launches through the profile that owns the session so `--resume` can find it.

`session-search` now prints `claude::resume <id>` instead of the bare `claude --resume <id>`, so a copy-pasted resume command lands you in the right directory automatically.

Verified: example session resolves + routes to the ant profile; a `.claude` session routes to the default profile; bad/missing args fail fast; `search.py` prints the new Resume line.