### PR TITLE
feat(pi): subscription switchers + pi::resume; session-search emits it

### DIFF
--- a/modules/agents/skills/session-search/SKILL.md
+++ b/modules/agents/skills/session-search/SKILL.md
@@ -56,7 +56,7 @@ For each matching session the script prints:
 
 - Searches `~/.claude*/projects/` (all config-dir variants), `~/.agents/projects/`, and `~/.pi/agent/sessions/` for session transcripts
 - History index from every `~/.claude*/history.jsonl` plus `~/.agents/history.jsonl`
-- Pi sessions are identified with `[pi]` label and show the file path instead of a resume command
+- Pi sessions are identified with `[pi]` label and resume via `pi::resume <id>` (cd's into the session's directory, then `pi --session <id>`; defined in `modules/pi/aliases.zsh`)
 - Pi artifacts (markdown files under `artifacts/`) are also searched and labelled `(pi artifact: <name>)`
 - Searches text content from user and assistant messages (skips tool calls, binary data, etc.)
 - Subagent files are not searched (only top-level session files)

--- a/modules/agents/skills/session-search/scripts/search.py
+++ b/modules/agents/skills/session-search/scripts/search.py
@@ -462,7 +462,9 @@ def format_timestamp(ts_ms: int) -> str:
 
 
 def _format_location(result: SearchResult) -> str:
-    if result.source in (SessionSource.PI, SessionSource.PI_ARTIFACT):
+    if result.source == SessionSource.PI:
+        return f"Resume:   pi::resume {result.session_id}"
+    if result.source == SessionSource.PI_ARTIFACT:
         return f"File:     {result.path}"
     return f"Resume:   claude::resume {result.session_id}"
 

--- a/modules/pi/aliases.zsh
+++ b/modules/pi/aliases.zsh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Subscription switchers for pi (@earendil-works/pi-coding-agent).
+#
+# Unlike Claude Code (one account per CLAUDE_CONFIG_DIR), pi keeps every
+# subscription in a single ~/.pi/agent and selects one per invocation via
+# --provider/--model. The OAuth Codex providers are named by pi itself
+# (openai-codex, openai-codex-2) and cannot be renamed — pi resolves them by
+# those built-in names — so the switchers below put a readable name on top.
+#
+# Accounts (see ~/.pi/agent/auth.json):
+#   ant-fellow-high-prio  Anthropic Fellows gateway, default interactive (opus 4.8)
+#   ant-fellow-batch      same gateway, batch tier (cheap async)
+#   openai-codex          ChatGPT Team Codex seat — email/password sign-in
+#   openai-codex-2        same Team workspace — Google sign-in
+
+pi::ant()        { pi --provider ant-fellow-high-prio --model 'claude-opus-4-8[fast]' "$@"; }
+pi::ant-batch()  { pi --provider ant-fellow-batch     --model 'claude-opus-4-8'       "$@"; }
+pi::codex()      { pi --provider openai-codex          --model gpt-5.5                 "$@"; }
+pi::codex-google() { pi --provider openai-codex-2      --model gpt-5.5                 "$@"; }
+
+# Resume a session by id, cd-ing into its original directory first — the pi
+# analogue of claude::resume. pi resumes by partial UUID (`--session <id>`) but
+# only finds the session from its original cwd, which session-search prints as
+# `pi::resume <id>`.
+pi::resume() {
+  emulate -L zsh
+  local id=$1
+  [[ -n $id ]] || { echo "pi::resume: usage: pi::resume <session-id>" >&2; return 1; }
+
+  # Sessions live at <config>/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl.
+  # Search every config-dir variant in case isolated PI_CODING_AGENT_DIR profiles
+  # are added later.
+  local file
+  file=$(command find "$HOME"/.pi*/agent/sessions -type f -name "*${id}*.jsonl" \
+           -print 2>/dev/null | head -1)
+  [[ -n $file ]] || { echo "pi::resume: no session '$id' under ~/.pi*/agent/sessions" >&2; return 1; }
+
+  # The session header line (type=session) records the real cwd.
+  local dir
+  dir=$(command grep -m1 -o '"cwd":"[^"]*"' "$file" | cut -d'"' -f4)
+  [[ -n $dir && -d $dir ]] || { echo "pi::resume: cannot resolve cwd for '$id' ($file)" >&2; return 1; }
+
+  cd "$dir" || return 1
+
+  # Route through the config dir that owns the session.
+  local cfg=${file%%/agent/sessions/*}
+  if [[ $cfg == "$HOME/.pi" ]]; then
+    pi --session "$id"
+  else
+    PI_CODING_AGENT_DIR=$cfg pi --session "$id"
+  fi
+}


### PR DESCRIPTION
Sets pi up for multiple subscriptions/sessions, mirroring the Claude helpers.

**Switchers** (`modules/pi/aliases.zsh`) — pi selects a subscription per invocation via `--provider`/`--model` (all accounts live in one `~/.pi/agent`, unlike Claude's per-`CLAUDE_CONFIG_DIR` accounts):
- `pi::ant` / `pi::ant-batch` — Anthropic Fellows gateway (opus 4.8 / batch tier)
- `pi::codex` / `pi::codex-google` — the two ChatGPT Team Codex seats (email-pw vs Google sign-in)

The OAuth Codex provider names (`openai-codex`, `openai-codex-2`) are fixed by pi — it resolves them by hardcoded built-in names and only tolerates an auto-appended `-N` account suffix, so they can't be renamed; the switchers put a readable name on top.

**`pi::resume <id>`** — finds the session across `~/.pi*/agent/sessions`, reads its `cwd` from the header line, `cd`s there, then `pi --session <id>`. `session-search` now prints `pi::resume <id>` for pi sessions instead of a bare file path.

Verified: switchers + `pi::resume` define and resolve a real session's cwd; `search.py` emits the `pi::resume` line for `[pi]` results and `claude::resume` for Claude ones; both files pass syntax checks.