### PR TITLE
docs(cmux): use canonical 'cmux workspace create' over legacy new-workspace

### DIFF
--- a/modules/agents/skills/cmux-workspace/SKILL.md
+++ b/modules/agents/skills/cmux-workspace/SKILL.md
@@ -105,7 +105,7 @@ Prefer explicit workspace flags even when env vars are set. It makes automation 
 
 ```bash
 # create a new workspace when the user asks for a new task area
-cmux new-workspace --name "debug auth" --cwd "$PWD"
+cmux workspace create --name "debug auth" --cwd "$PWD"
 
 # rename / close (only when explicitly requested)
 cmux rename-workspace --workspace "${CMUX_WORKSPACE_ID:-}" -- "build fix"

--- a/modules/agents/skills/cmux-workspace/references/commands.md
+++ b/modules/agents/skills/cmux-workspace/references/commands.md
@@ -22,9 +22,9 @@ cmux close-window --window window:2
 
 cmux list-workspaces
 cmux list-workspaces --json
-cmux new-workspace --name "task" --cwd "$PWD"
-cmux new-workspace --command "npm run dev"
-cmux new-workspace --layout '{"root":{"type":"terminal"}}'
+cmux workspace create --name "task" --cwd "$PWD"
+cmux workspace create --command "npm run dev"
+cmux workspace create --layout '{"root":{"type":"terminal"}}'
 cmux current-workspace
 cmux select-workspace --workspace workspace:2
 cmux rename-workspace --workspace workspace:2 -- "new name"

--- a/modules/agents/skills/cmux/SKILL.md
+++ b/modules/agents/skills/cmux/SKILL.md
@@ -27,7 +27,7 @@ cmux list-panes
 cmux list-pane-surfaces --pane pane:1
 
 # create/focus/move
-cmux new-workspace
+cmux workspace create
 cmux new-split right --panel pane:1
 cmux move-surface --surface surface:7 --pane pane:2 --focus true
 cmux split-off --surface surface:7 right

--- a/modules/agents/skills/cmux/references/windows-workspaces.md
+++ b/modules/agents/skills/cmux/references/windows-workspaces.md
@@ -18,7 +18,7 @@ cmux new-window
 cmux focus-window --window window:2
 cmux close-window --window window:2
 
-cmux new-workspace
+cmux workspace create
 cmux select-workspace --workspace workspace:4
 cmux close-workspace --workspace workspace:4
 ```


### PR DESCRIPTION
cmux made `new-workspace` a legacy alias for `cmux workspace create`. Updates the cmux/cmux-workspace skill docs to the canonical command.

Left unchanged: `move-tab-to-new-workspace` (different command), the `new-workspace placement` setting reference (prose, not a command), and generated snapshot scripts under `~/.config/cmux` (the legacy alias keeps working). The untracked `cmux-durable` skill also got the same edits locally but stays out of this PR.