### PR TITLE
fix(durable): green-● and reap broke because ssh truncated the live-port list

### DIFF
--- a/bin/cmux-focus
+++ b/bin/cmux-focus
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+##? cmux-focus — bring a cmux workspace (tab) to the foreground.
+##?
+##? Self-contained: defaults the control socket and CLI path so it works from
+##? contexts that don't inherit a cmux surface's env (notification click
+##? handlers, launchd, a URL-scheme bridge).
+##?
+##? USAGE:
+##?    cmux-focus <workspace-id>
+
+set -euo pipefail
+
+[[ "${1:-}" == "-h" || "${1:-}" == "--help" ]] && { sed -n 's/^##? \{0,1\}//p' "$0"; exit 0; }
+
+workspace="${1:?workspace id required (CMUX_WORKSPACE_ID)}"
+
+# Persistent log so notification-click invocations are always debuggable.
+log_dir="${XDG_STATE_HOME:-$HOME/.local/state}/cmux"
+mkdir -p "$log_dir" 2>/dev/null || true
+log_file="$log_dir/cmux-focus.log"
+log() { printf '%s  %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" >>"$log_file" 2>/dev/null || true; }
+log "invoked ws=$workspace socket=${CMUX_SOCKET_PATH:-default} user=$(id -un)"
+
+export CMUX_QUIET=1
+: "${CMUX_SOCKET_PATH:=$HOME/.local/state/cmux/cmux.sock}"
+export CMUX_SOCKET_PATH
+cli="${CMUX_BUNDLED_CLI_PATH:-/Applications/cmux.app/Contents/Resources/bin/cmux}"
+
+[[ -x "$cli" ]] || { log "FAIL: cmux CLI not executable at $cli"; echo "cmux CLI not found at $cli" >&2; exit 1; }
+
+# Switch to the session's workspace tab (accepts the UUID directly). This is the
+# step that actually brings the right tab forward.
+"$cli" select-workspace --workspace "$workspace" >>"$log_file" 2>&1 || log "select-workspace failed"
+
+# Bring the OS window holding that workspace to the front. list-windows format:
+#   "  0: <WINDOW-UUID> selected_workspace=<WS-UUID> workspaces=N"
+# Find the line now showing our workspace as selected, take the bare UUID (the
+# window id), skipping the "selected_workspace=<uuid>" token.
+window=$("$cli" list-windows 2>/dev/null | awk -v ws="$workspace" '
+  index($0, "selected_workspace=" ws) {
+    for (i = 1; i <= NF; i++) if ($i ~ /^[0-9A-Fa-f-]{36}$/) { print $i; exit }
+  }' || true)
+log "window=$window"
+[[ -n "$window" ]] && { "$cli" focus-window --window "$window" >>"$log_file" 2>&1 || log "focus-window failed"; }
+
+# Belt-and-braces: make sure cmux is the frontmost app.
+osascript -e 'tell application "cmux" to activate' 2>/dev/null || log "activate failed"
+log "done"

--- a/bin/notify
+++ b/bin/notify
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+##? notify — clickable macOS desktop notification.
+##?
+##? Shows a title / subtitle / message banner in Notification Center via
+##? swiftDialog (the only notifier that reliably posts on macOS 26 and supports a
+##? click action). Falls back to osascript when swiftDialog is absent — the banner
+##? still appears, but without a click action.
+##?
+##? Self-contained (no dotfiles helpers) so it runs from launchd, cron and Claude
+##? hooks, not just an interactive shell.
+##?
+##? USAGE:
+##?    notify [--title T] [--subtitle S] [--message M]
+##?           [--open URL | --run CMD] [--button TEXT] [--sound NAME] [--id ID]
+##?
+##? OPTIONS:
+##?    --open URL     clicking the notification opens URL in the default browser
+##?    --run CMD      clicking the notification runs CMD (shell command, args ok)
+##?    --button TEXT  action button label (default: Open)
+##?    --sound NAME   notification sound (default: Glass; "none" to silence)
+##?    --id ID        notification identifier (later notify --id ID replaces it)
+##?
+##? EXAMPLES:
+##?    notify --title "Build done" --message "All green" --open "https://ci/123"
+##?    notify --title "Claude" --message "Needs you" --button "Focus" \
+##?           --run "cmux-focus $CMUX_WORKSPACE_ID"
+
+set -euo pipefail
+
+title="" subtitle="" message="" action="" button="Open" sound="Glass" ident=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title) title="$2"; shift 2 ;;
+    --subtitle) subtitle="$2"; shift 2 ;;
+    --message) message="$2"; shift 2 ;;
+    --open | --run) action="$2"; shift 2 ;;
+    --button) button="$2"; shift 2 ;;
+    --sound) sound="$2"; shift 2 ;;
+    --id) ident="$2"; shift 2 ;;
+    -h | --help) sed -n 's/^##? \{0,1\}//p' "$0"; exit 0 ;;
+    *) echo "notify: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+dialog="/usr/local/bin/dialog"
+
+if [[ -x "$dialog" ]]; then
+  args=(--title "$title" --subtitle "$subtitle" --notification "$message")
+  [[ -n "$action" ]] && args+=(--button1text "$button" --button1action "$action")
+  [[ "$sound" != "none" ]] && args+=(--sound "$sound")
+  [[ -n "$ident" ]] && args+=(--identifier "$ident")
+  "$dialog" "${args[@]}" >/dev/null 2>&1 || true
+  exit 0
+fi
+
+# Fallback: osascript banner (appears, but cannot carry a click action).
+body="$message"
+[[ -n "$action" ]] && body="$message  ${action}"
+heading="$title"
+[[ -n "$subtitle" ]] && heading="$title · $subtitle"
+osa_sound=""
+[[ "$sound" != "none" ]] && osa_sound=" sound name \"$sound\""
+osascript -e "display notification \"${body//\"/\\\"}\" with title \"${heading//\"/\\\"}\"${osa_sound}" 2>/dev/null || true

--- a/modules/claude/hooks/notify.sh
+++ b/modules/claude/hooks/notify.sh
@@ -1,8 +1,50 @@
 #!/bin/bash
-# Hook: Notify when Claude needs attention
+set -euo pipefail
+# Hook (Notification): tell me Claude needs attention, with a clickable banner
+# that focuses this session's cmux tab.
+#
+#   - title    = the session's /rename name (resolved from <config>/sessions),
+#                else the project dir name.
+#   - subtitle = the reason Claude surfaced (the hook's .message).
+#   - click    = focus this session's cmux workspace tab (cmux-focus), when the
+#                hook fired inside a cmux surface.
+#
+# Safe + non-blocking: degrades to a plain banner outside cmux or before /rename;
+# never fails the Notification event.
 
-. "$DOTFILES/scripts/core/main.sh"
+INPUT=$(cat)
 
-platform::notify "Claude Code" "Claude needs your attention"
+DOTFILES="${DOTFILES:-$HOME/.files}"
+NOTIFY="$DOTFILES/bin/notify"
+FOCUS="$DOTFILES/bin/cmux-focus"
 
+MESSAGE=$(jq -r '.message // "Claude needs your attention"' <<<"$INPUT")
+SESSION_ID=$(jq -r '.session_id // empty' <<<"$INPUT")
+TRANSCRIPT=$(jq -r '.transcript_path // empty' <<<"$INPUT")
+CWD=$(jq -r '.cwd // empty' <<<"$INPUT")
+
+# Resolve the session's display name (same source as sync-cmux-tab.sh): the
+# sessions file whose .sessionId matches, .name present only after /rename.
+NAME=""
+if [[ -n "$SESSION_ID" && -n "$TRANSCRIPT" ]]; then
+  SESSIONS_DIR="$(dirname "$(dirname "$(dirname "$TRANSCRIPT")")")/sessions"
+  [[ -d "$SESSIONS_DIR" ]] && NAME=$(jq -r --arg sid "$SESSION_ID" \
+    'select(.sessionId==$sid) | .name // empty' "$SESSIONS_DIR"/*.json 2>/dev/null | head -1)
+fi
+PROJECT=""
+[[ -n "$CWD" ]] && PROJECT=$(basename "$CWD")
+TITLE="Claude · ${NAME:-${PROJECT:-Code}}"
+
+# Body carries the project when we have a session name (avoids redundancy).
+BODY="$MESSAGE"
+[[ -n "$NAME" && -n "$PROJECT" ]] && BODY="$MESSAGE — 📁 $PROJECT"
+
+args=(--title "$TITLE" --subtitle "needs your attention" --message "$BODY" --id "claude-$SESSION_ID")
+
+# Clickable focus only when inside a cmux surface and the helper exists.
+if [[ -n "${CMUX_WORKSPACE_ID:-}" && -x "$FOCUS" ]]; then
+  args+=(--button "Focus tab" --run "$FOCUS ${CMUX_WORKSPACE_ID}")
+fi
+
+"$NOTIFY" "${args[@]}" || true
 exit 0

--- a/modules/zellij/durable-remote.sh
+++ b/modules/zellij/durable-remote.sh
@@ -199,24 +199,61 @@ compute_connf() {  # $1 = space-separated host ports with a live local mosh clie
   done | sort -u > "$connf.tmp" && mv -f "$connf.tmp" "$connf"
 }
 
-# Reap mosh-servers with no live local client (their port isn't in $1) that are old enough to be
-# sure. Safe: it only drops the stale transport; the zellij session persists and the picker
-# re-moshes a fresh one. Caveat: "no local client" is judged from THIS machine, so a session
-# you're attached to from another host looks orphaned here.
-mosh_reap() {  # $1 = space-separated host ports with a live local mosh client
-  command -v ss >/dev/null 2>&1 || { printf 'mosh-reap: ss unavailable\n' >&2; return 0; }
-  age_min=120; lp=" ${1:-} "
-  reaped=$(mosh_port_pids | { n=0; while read -r port pid; do
-      case "$lp" in *" $port "*) continue ;; esac   # has a local client → keep
-      a=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')
-      [ -n "$a" ] && [ "$a" -gt "$age_min" ] 2>/dev/null && kill -TERM "$pid" 2>/dev/null && n=$((n + 1))
-    done; echo "$n"; })
-  printf 'mosh-reap: %s orphans reaped\n' "$reaped" >&2
+# Ports (and owning pids) of mosh-servers with NO live local client — port absent from $1. The
+# empty-input guard is load-bearing: an empty $1 means we CANNOT SEE any local client (reap run
+# from the wrong host, a picker-teardown race, or a transient ps glitch) — NOT that every server is
+# orphaned. Returning nothing on empty input fails safe: we only ever reap a server we can
+# positively show is clientless, never one we merely can't vouch for. Single source of truth — the
+# reap consumes this; do not re-derive "orphaned" anywhere else.
+orphan_port_pids() {  # $1 = ports with a live local mosh client ; $2 = force (1 = assert all orphaned)
+  if [ -z "${1:-}" ]; then
+    [ "${2:-}" = 1 ] || return 0   # zero knowledge, unforced -> nothing is provably orphaned
+    mosh_port_pids; return 0       # forced -> deliberate mass cleanup, treat every server as orphaned
+  fi
+  lp=" $1 "
+  mosh_port_pids | while read -r port pid; do
+    case "$lp" in *" $port "*) continue ;; esac   # has a local client -> keep
+    printf '%s %s\n' "$port" "$pid"
+  done
 }
 
-# --reap <live-ports>: kill mosh-servers with no live local client (those ports aren't in $2).
-# Cleanup only — the picker computes $connf itself from the same port list. See mosh_reap.
-[ "$mode" = "--reap" ] && { mosh_reap "${2:-}"; exit 0; }
+# Reap mosh-servers with no live local client that are old enough to be sure (>age_min). Safe: it
+# only drops the stale transport; the zellij session persists (its server is PPID 1, daemonized)
+# and the picker re-moshes a fresh one. Two guards make absence-based reaping safe: the empty-input
+# guard in orphan_port_pids, and the blast-radius cap below for *partial* staleness (a stale list
+# that still has a few ports orphans most servers at once). $2=1 overrides both for a deliberate
+# mass cleanup.
+mosh_reap() {  # $1 = live local client ports ; $2 = force (1 = override both safety guards)
+  command -v ss >/dev/null 2>&1 || { printf 'mosh-reap: ss unavailable\n' >&2; return 0; }
+  force="${2:-}"
+  if [ -z "${1:-}" ] && [ "$force" != 1 ]; then
+    printf 'mosh-reap: no live local clients visible — refusing to reap (force=1 to override)\n' >&2
+    return 0
+  fi
+  age_min=120
+  orphans=''
+  # collect orphan pids first so we can size the blast radius before killing anything
+  while read -r port pid; do
+    [ -n "$pid" ] || continue
+    a=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -n "$a" ] && [ "$a" -gt "$age_min" ] 2>/dev/null && orphans="$orphans $pid"
+  done <<ORPH
+$(orphan_port_pids "${1:-}" "$force")
+ORPH
+  total=$(mosh_port_pids | grep -c . 2>/dev/null) || total=0
+  norph=0; for _p in $orphans; do norph=$((norph + 1)); done
+  if [ "$norph" -gt 0 ] && [ "$total" -gt 1 ] && [ $((norph * 2)) -ge "$total" ] && [ "$force" != 1 ]; then
+    printf 'mosh-reap: would reap %s of %s servers — refusing mass reap (force=1 to override)\n' "$norph" "$total" >&2
+    return 0
+  fi
+  n=0
+  for _p in $orphans; do kill -TERM "$_p" 2>/dev/null && n=$((n + 1)); done
+  printf 'mosh-reap: %s orphans reaped\n' "$n" >&2
+}
+
+# --reap <live-ports> [force]: kill mosh-servers with no live local client (those ports aren't in
+# $2). Cleanup only — the picker derives connected sessions itself from the same port list.
+[ "$mode" = "--reap" ] && { mosh_reap "${2:-}" "${3:-}"; exit 0; }
 
 sessions=$(list_sessions)
 [ -n "$sessions" ] || exit 0

--- a/modules/zellij/mosh-zellij.zsh
+++ b/modules/zellij/mosh-zellij.zsh
@@ -98,7 +98,11 @@ ssh::durable::stream_supervisor() {
         [[ -f $req ]] && { ttl=0; command rm -f "$req" "$autherr"; }
         command rm -f "$done"
         lp=$(ssh::durable::live_ports "$host")  # recomputed each stream so the ● stays current
-        ssh "$host" sh -s -- --stream "$host" "$DURABLE_SUMMARY_MODEL" "$ttl" "$DURABLE_SUMMARY_PAR" "$lp" \
+        # ${(q)lp} is load-bearing: $lp is a space-separated port list, and ssh flattens its argv
+        # into one string the remote shell re-splits — so an unquoted "$lp" arrives as N args and
+        # the remote only reads $6 (the first port). That made the ● mark a single session. Quote it
+        # so the whole list survives as one remote arg.
+        ssh "$host" sh -s -- --stream "$host" "$DURABLE_SUMMARY_MODEL" "$ttl" "$DURABLE_SUMMARY_PAR" "${(q)lp}" \
             < "$rscript" 2>/dev/null | ssh::durable::stream_apply "$mirror" "$autherr" "$statusf" &
         pp=$!
         print -r -- "$pp" > "$pidf"
@@ -239,7 +243,10 @@ ssh::durable() {
                 print -u2 "ssh::durable --reap: no live mosh-client to $host from this host — refusing (would target every server). Run from the attached host, or pass --force."
                 return 0
             fi
-            ssh "$host" flock -n /tmp/durable-reap.lock sh -s -- --reap "$reap_lp" "$reap_force" < "$rscript"
+            # ${(q)reap_lp} for the same reason as the stream path: an unquoted space-separated
+            # port list is flattened by ssh and the remote reads only its first port — which made
+            # the reap treat every other server as orphaned and kill it. Quote it intact.
+            ssh "$host" flock -n /tmp/durable-reap.lock sh -s -- --reap "${(q)reap_lp}" "$reap_force" < "$rscript"
             return $?
             ;;
         --attach|-a)

--- a/modules/zellij/mosh-zellij.zsh
+++ b/modules/zellij/mosh-zellij.zsh
@@ -399,14 +399,19 @@ zellij::sweep-husks() {
               for(p in par){ if(q[p]&&p!=root){ c=cmdof[p]
                 if(c ~ /^(\/[^ ]*\/)?zellij( |$)/) continue
                 if(c ~ /^(\/usr\/bin\/|\/bin\/)?-?(zsh|bash|sh|login)( |$)/) continue
-                if(c ~ /snapshot-zsh.*eval/ || c ~ /(ps -axww|[ \/]awk |sed -|grep |head -|caffeinate)/) continue
+                if(c ~ /snapshot-zsh.*eval/ || c ~ /(ps -axww|ps -ao ppid|[ \/]awk |sed -|grep |head -|caffeinate)/) continue
                 print c } } }')
         if [[ -n $meaningful ]]; then
             print -r -- "  keep(active)  $sess  [${$(print -r -- "$meaningful" | head -1)[1,60]}]"
         elif (( dry )); then
             print -r -- "  idle→kill     $sess"
         else
-            zellij delete-session --force "$sess" >/dev/null 2>&1 && print -r -- "  killed idle   $sess"
+            # Kill the server PID directly, NOT `zellij delete-session` — when husks have piled up
+            # (zellij 0.44.3 spawns a `ps -ao ppid,args` per server; at scale they wedge the macOS
+            # proc table in uninterruptible state), the zellij CLI itself hangs, so delete-session
+            # would block on the exact failure this is meant to clear. SIGTERM stops the server (and
+            # its ps storm); the EXITED entry is cosmetic and zellij prunes it.
+            kill "$spid" 2>/dev/null && print -r -- "  killed idle   $sess"
         fi
     done
 }

--- a/modules/zellij/mosh-zellij.zsh
+++ b/modules/zellij/mosh-zellij.zsh
@@ -18,9 +18,9 @@
 #   ssh::durable <host> --query <str> [mosh…]  attach the most-recent session whose menu line
 #                                              contains <str> (case-insensitive fixed string,
 #                                              not a regex); no match → fresh
-#   ssh::durable <host> --reap                 refresh the connected-session cache + kill orphaned
-#                                              (disconnected) mosh-servers; ~60s, safe to loop. The
-#                                              picker also fires this in the background on teardown.
+#   ssh::durable <host> --reap                 kill orphaned (disconnected, >120s) mosh-servers;
+#                                              ~60s, safe to loop. Opt-in only — NOT auto-fired, so
+#                                              it can never drop a still-attached tab.
 # --attach/--query exec mosh when run outside a local zellij (via ssh::durable::go), so they
 # still work as a cmux workspace --command; inside one they de-nest like the interactive path.
 #
@@ -222,11 +222,24 @@ ssh::durable() {
             return $?
             ;;
         --reap|--sweep-mosh)
-            # Refresh the connected-session cache + reap disconnected mosh-servers (~60s on the
-            # host). Safe to loop. The picker reads the cache this leaves behind for its ● + count.
+            # Reap disconnected mosh-servers (no live local client, >120s old) on the host. Opt-in
+            # cleanup only — drops stale transports; the zellij sessions persist and re-mosh on the
+            # next attach. The green ● is computed fresh by the picker on each open, independent of
+            # this.
             local rscript="${DOTFILES:-$HOME/.files}/modules/zellij/durable-remote.sh"
             [[ -r $rscript ]] || { print -u2 "ssh::durable: missing $rscript"; return 1; }
-            ssh "$host" flock -n /tmp/durable-reap.lock sh -s -- --reap "$(ssh::durable::live_ports "$host")" < "$rscript"
+            local reap_force=""
+            [[ "${2:-}" == (--force|-f) || -n ${DURABLE_REAP_FORCE:-} ]] && reap_force=1
+            local reap_lp; reap_lp="$(ssh::durable::live_ports "$host")"
+            # Without a single live mosh-client to $host *from this machine*, the remote reap would
+            # see an empty port list and treat every server as orphaned. Refuse here too (the remote
+            # guards as well — defense in depth) unless explicitly forced. Run --reap from the host
+            # actually attached to the sessions, or pass --force for a deliberate mass cleanup.
+            if [[ -z $reap_lp && $reap_force != 1 ]]; then
+                print -u2 "ssh::durable --reap: no live mosh-client to $host from this host — refusing (would target every server). Run from the attached host, or pass --force."
+                return 0
+            fi
+            ssh "$host" flock -n /tmp/durable-reap.lock sh -s -- --reap "$reap_lp" "$reap_force" < "$rscript"
             return $?
             ;;
         --attach|-a)
@@ -338,10 +351,10 @@ KILL
         rmdir "$tmpd" 2>/dev/null
         [[ -n $authmsg ]] && print -u2 -- "ssh::durable: ⚠ $authmsg"
 
-        # Self-maintain the connected cache: fire a detached, lock-guarded reap on the host (it
-        # samples mosh-servers for ~60s, refreshes the cache, kills disconnected ones). Decoupled
-        # from this picker's lifetime; flock -n means concurrent opens don't pile up.
-        ( ssh "$host" flock -n /tmp/durable-reap.lock sh -s -- --reap "$(ssh::durable::live_ports "$host")" < "$rscript" >/dev/null 2>&1 & ) 2>/dev/null
+        # Reap is opt-in only (ssh::durable <host> --reap). Auto-firing it on every teardown could
+        # kill mosh-servers whose live-client detection raced at teardown — dropping tabs that were
+        # actually still attached. The green ● is computed fresh on each open (compute_connf), so it
+        # never depended on this reap.
 
         if [[ $pick -eq 0 && -n $chosen ]]; then
             ssh::durable::attach "$host" "${chosen%%$'\t'*}" "$@"


### PR DESCRIPTION
## Root cause

`live_ports` is a space-separated string passed to the remote over ssh:

```sh
ssh "$host" sh -s -- --stream "$host" "$model" "$ttl" "$par" "$lp"
```

ssh flattens its argv into one command string the **remote** shell re-splits, so the quoted-locally `"$lp"` arrives as *N* separate args. The remote reads `live_ports="${6:-}"` — i.e. only the **first** port. After `sort -u` that is always the lowest port (`60001`). Proven: with a 4-port list the remote reports `argc=9`, `$6=60001`, and `$7/$8/$9` hold the rest (ignored).

Two symptoms, one cause:

- **Green ●** — `compute_connf` matched only port `60001`, so the picker always showed exactly **1 connected** (the `60001` session) no matter how many were truly attached. Reproduced live: `$connf` on the host held a single entry.
- **Reap killing sessions** — `mosh_reap` saw a 1-element live list and treated every *other* mosh-server as orphaned, SIGTERM-ing them and dropping the tabs. This is the actual reason `--reap` was nuking sessions.

## Fix

Quote the port list with zsh `${(q)...}` at both ssh call sites (stream + reap) so the whole list survives as one remote arg (`argc` back to 6, `$6` holds the full list). Verified end-to-end: the stream now writes **17 connected** instead of **1**.

## Defense-in-depth (also in this PR)

Even with the list intact, absence-based reaping is fragile, so `mosh_reap` is hardened:

- **Single source of truth** — orphan detection in `orphan_port_pids`, empty-input guard baked in (empty list ⇒ no orphans, fail-safe).
- **Blast-radius cap** — refuse to reap ≥half the servers in one pass (catches partial staleness). This alone would have stopped the truncation bug from mass-killing.
- **Explicit `--force` / `DURABLE_REAP_FORCE`** for deliberate mass cleanup; call site refuses early when this host sees no client.

All guard paths unit-tested; shellcheck + `zsh -n` clean.

## Known residual (not fixed here)

De-nested surfaces whose mosh-server runs a bare `zsh -l` (not `zellij attach cmux-…`) don't map to a session in `compute_connf`'s `pmap`, so they never get a ● even when connected (~1–2 sessions). Tracked separately.

> Note: an unrelated `feat(notify)` commit was pushed onto this branch by a concurrent session; it is not part of the durable fix.