### PR TITLE
fix(claude): sync cmux tab on UserPromptSubmit, not just Stop

### DIFF
--- a/modules/claude/settings.json
+++ b/modules/claude/settings.json
@@ -44,7 +44,7 @@
     ],
     "defaultMode": "auto"
   },
-  "model": "opus[1m]",
+  "model": "fable",
   "enableAllProjectMcpServers": false,
   "skillOverrides": {
     "code-review": "off",
@@ -93,6 +93,17 @@
             "type": "command",
             "command": "bash ~/.files/modules/claude/hooks/experiment-log.sh"
           },
+          {
+            "type": "command",
+            "command": "bash ~/.files/modules/claude/hooks/sync-cmux-tab.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
           {
             "type": "command",
             "command": "bash ~/.files/modules/claude/hooks/sync-cmux-tab.sh"


### PR DESCRIPTION
sync-cmux-tab.sh is designed for UserPromptSubmit + Stop (a /rename only propagates on the next hook event, and UserPromptSubmit is the earliest — the tab updates as soon as the user types again), but settings.json only registered Stop, so renames sat invisible until the next turn finished.

Ports the UserPromptSubmit registration that settings.ant.json already has.