### PR TITLE
fix(skills): add source frontmatter to emil-design-eng

### DIFF
--- a/modules/agents/skills/emil-design-eng/SKILL.md
+++ b/modules/agents/skills/emil-design-eng/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: emil-design-eng
 description: This skill encodes Emil Kowalski's philosophy on UI polish, component design, animation decisions, and the invisible details that make software feel great.
+source: https://github.com/emilkowalski/skills/tree/main/skills/emil-design-eng
 ---
 
 # Design Engineering


### PR DESCRIPTION
Follow-up to #36, resolving review finding F1 (P3 — convention): vendored skills record their upstream in a `source:` frontmatter line, matching `ask-questions-if-underspecified`, `audit-context-building`, `brainstorming`, `differential-review`, `frontend-design`, and `systematic-debugging`.

One-line change: adds `source: https://github.com/emilkowalski/skills/tree/main/skills/emil-design-eng` to the frontmatter. The vendored body remains byte-identical to upstream.

Verified: `scripts/check-crypt-patterns.sh` passes; gitleaks (staged) and trufflehog report no secrets.

_[via gantry](https://gantry.hails.info/run/brisk-fleet-stork)_