### PR TITLE
fix(hooks): sync-cmux-tab must never block the prompt — fail open on any error

### DIFF
--- a/modules/claude/hooks/sync-cmux-tab.sh
+++ b/modules/claude/hooks/sync-cmux-tab.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-set -euo pipefail
+set -Eeuo pipefail
+# A non-zero UserPromptSubmit hook BLOCKS the prompt — including automated wakes
+# (background-task notifications), which stranded headless gantry workers when
+# this hook died under set -e. Fail open: any unexpected error is a silent no-op.
+trap 'exit 0' ERR
 # Hook (UserPromptSubmit + Stop): keep the cmux panel (the per-surface tab in a
 # pane's tab bar) in step with the Claude session name (set by /rename). cmux
 # already syncs the *workspace* name; the panel/surface tab is not, so we do it.
@@ -52,8 +56,10 @@ SESSIONS_DIR="$CONFIG_DIR/sessions"
 [[ -d "$SESSIONS_DIR" ]] || exit 0
 
 # The session name (.name) is absent until the first /rename — no clobber then.
+# `|| true`: an empty *.json glob reaches jq unexpanded and fails the pipeline
+# under pipefail (the exact silent-block seen in headless workers).
 NAME=$(jq -r --arg sid "$SESSION_ID" \
-  'select(.sessionId==$sid) | .name // empty' "$SESSIONS_DIR"/*.json 2>/dev/null | head -1)
+  'select(.sessionId==$sid) | .name // empty' "$SESSIONS_DIR"/*.json 2>/dev/null | head -1 || true)
 [[ -n "$NAME" ]] || exit 0
 
 # Churn guard: everything past here only runs when the name actually changed, so


### PR DESCRIPTION
A non-zero UserPromptSubmit hook **blocks the prompt** — including automated wakes (background-task notifications). In headless gantry workers (djrhails-dev image, no cmux) the empty sessions `*.json` glob reached jq unexpanded, failed the pipeline under `pipefail`, and `set -e` killed the hook with stderr already silenced (`2>/dev/null`) — Claude Code reported *"blocked by hook … No stderr output"* and every background-task wake became an empty session-started/turn-completed pair. A worker parked waiting on a background task could never be woken by its completion (observed on gantry `thrd_gilded-neat-hawk`, 2026-07-06).

Two changes:
- `|| true` on the known-failing `NAME=$(jq … | head -1)` pipeline (empty glob → jq error → pipefail).
- `set -E` + `trap 'exit 0' ERR` so **any** unexpected failure is a silent no-op, making the hook's long-stated contract ("always exits 0 so it never blocks the prompt") structural instead of aspirational.

Verified: reproduced the container failure locally (old hook exits 2 on an empty sessions glob with lib present; fixed hook exits 0 on the same input); shellcheck clean.