### PR TITLE
feat(pi): current package name + web-access/subagents/fff extensions

### DIFF
--- a/modules/pi/install.sh
+++ b/modules/pi/install.sh
@@ -2,7 +2,7 @@
 . "$DOTFILES/scripts/core/main.sh"
 
 if ! platform::command_exists "pi"; then
-  log::execute "npm install -g @mariozechner/pi-coding-agent" \
+  log::execute "npm install -g @earendil-works/pi-coding-agent" \
     "pi-coding-agent"
 else
   log::success "pi-coding-agent"
@@ -25,4 +25,16 @@ if platform::command_exists "pi"; then
   log::execute \
     "pi install npm:pi-multi-pass" \
     "pi-multi-pass"
+
+  log::execute \
+    "pi install npm:pi-web-access" \
+    "pi-web-access"
+
+  log::execute \
+    "pi install npm:pi-subagents" \
+    "pi-subagents"
+
+  log::execute \
+    "pi install npm:@ff-labs/pi-fff" \
+    "pi-fff"
 fi

--- a/modules/pi/settings.json
+++ b/modules/pi/settings.json
@@ -3,6 +3,9 @@
     "git:github.com/DJRHails/pi-interactive-subagents",
     "git:github.com/pasky/chrome-cdp-skill",
     "git:github.com/DJRHails/pi-smart-sessions",
-    "npm:pi-multi-pass"
+    "npm:pi-multi-pass",
+    "npm:pi-web-access",
+    "npm:pi-subagents",
+    "npm:@ff-labs/pi-fff"
   ]
 }


### PR DESCRIPTION
Switches the pi module to the current `@earendil-works/pi-coding-agent` package (the `@mariozechner` name is deprecated on npm) and adds three extensions to the managed set, in both `install.sh` and the declarative `settings.json`:

- `npm:pi-web-access`
- `npm:pi-subagents`
- `npm:@ff-labs/pi-fff`

Groundwork for gantry's pi worker harness: the worker image bootstraps this module so `pi` + extensions ride the dotfiles, not ad-hoc installs.