### PR TITLE
fix(pi): migrate existing installs off deprecated @mariozechner package

### DIFF
--- a/modules/pi/install.sh
+++ b/modules/pi/install.sh
@@ -4,6 +4,11 @@
 if ! platform::command_exists "pi"; then
   log::execute "npm install -g @earendil-works/pi-coding-agent" \
     "pi-coding-agent"
+elif npm ls -g @mariozechner/pi-coding-agent > /dev/null 2>&1; then
+  # The @mariozechner name is deprecated on npm and receives no new releases.
+  log::execute \
+    "npm uninstall -g @mariozechner/pi-coding-agent && npm install -g @earendil-works/pi-coding-agent" \
+    "pi-coding-agent (migrate to @earendil-works)"
 else
   log::success "pi-coding-agent"
 fi


### PR DESCRIPTION
Follow-up to #39, resolving review finding F1 (https://github.com/DJRHails/dotfiles/pull/39#discussion_r3531808040).

The package rename in #39 only took effect on machines where `pi` wasn't installed yet: anywhere the deprecated `@mariozechner/pi-coding-agent` was already present, `platform::command_exists "pi"` short-circuited to `log::success`, pinning that machine to the dead package name (frozen at 0.73.1; releases continue only on `@earendil-works/pi-coding-agent`, currently 0.80.3).

This adds a migration branch: when the old global package is detected via `npm ls -g`, uninstall it and install the new name. Fresh installs and already-migrated machines are unaffected (`npm ls -g` exits nonzero → falls through to `log::success`).

**Verification:** `bash -n` and `shellcheck` clean (SC1091 info pre-existing); the `npm ls -g` probe tested both ways — exit 0 for an installed global package, exit 1 for an absent one. Pre-commit hooks (gitleaks, trufflehog, transcrypt check) passed.

_[via gantry](https://gantry.hails.info/run/fair-marble-owl)_