### PR TITLE
fix(pi): sudo the global npm install on Linux (NodeSource system prefix)

### DIFF
--- a/modules/pi/install.sh
+++ b/modules/pi/install.sh
@@ -1,11 +1,17 @@
 # shellcheck shell=bash
 . "$DOTFILES/scripts/core/main.sh"
 
-if ! platform::command_exists "pi"; then
+# Linux node comes from the NodeSource apt repo (modules/node), whose global
+# prefix is system-owned — npm -g needs sudo there, like the node module's own
+# pnpm fallback. macOS (brew) keeps a user-writable node bin dir.
+if platform::command_exists "pi"; then
+  log::success "pi-coding-agent"
+elif platform::is_osx; then
   log::execute "npm install -g @earendil-works/pi-coding-agent" \
     "pi-coding-agent"
 else
-  log::success "pi-coding-agent"
+  log::execute "sudo npm install -g @earendil-works/pi-coding-agent" \
+    "pi-coding-agent"
 fi
 
 # Install pi extensions


### PR DESCRIPTION
npm -g needs sudo under the NodeSource apt prefix (Linux); without it the pi install fails EACCES inside the gantry worker image bootstrap (unprivileged `dev` user) and the module's extension installs are silently skipped. Same pattern as the node module's `sudo corepack enable pnpm` fallback.