### PR TITLE
fix(pi,node): use platform::sudo for Linux npm-global fallbacks

### DIFF
--- a/modules/node/install.sh
+++ b/modules/node/install.sh
@@ -27,6 +27,6 @@ elif platform::is_osx; then
   corepack enable pnpm 2>/dev/null || npm install -g pnpm
   log::result $? "pnpm"
 else
-  sudo corepack enable pnpm 2>/dev/null || sudo npm install -g pnpm
+  platform::sudo corepack enable pnpm 2>/dev/null || platform::sudo npm install -g pnpm
   log::result $? "pnpm"
 fi

--- a/modules/pi/install.sh
+++ b/modules/pi/install.sh
@@ -10,7 +10,7 @@ elif platform::is_osx; then
   log::execute "npm install -g @earendil-works/pi-coding-agent" \
     "pi-coding-agent"
 else
-  log::execute "sudo npm install -g @earendil-works/pi-coding-agent" \
+  log::execute "platform::sudo npm install -g @earendil-works/pi-coding-agent" \
     "pi-coding-agent"
 fi
 


### PR DESCRIPTION
Follow-up to #41 (already merged), addressing the P3 review finding on that PR.

#41 mirrored the `node` pnpm fallback's bare `sudo`, but bare `sudo` is the repo's minority idiom — ~15 modules (node's apt path, docker, tailscale, keybase, cloudflared, git…) use the `platform::sudo` helper, and the only two bare-`sudo` install sites were pi's new line and the pnpm fallback it copied.

`platform::sudo` (`scripts/core/platform.sh`) runs `sudo "$@"` only when `EUID != 0`, else runs the command directly. Bare `sudo` fails `command not found` if the module bootstraps as root in an image without `sudo` on PATH (common in minimal root containers), where `platform::sudo` no-ops to a direct install that root can perform (root already owns the NodeSource `/usr` prefix). Not a problem in the current gantry image (unprivileged `dev`, sudo present), hence P3.

Closes the bug class across both sites:
- `modules/pi/install.sh` — pi-coding-agent global install
- `modules/node/install.sh` — pnpm corepack/npm fallback

## Verification
- `bash -n` on both files ✓
- `shellcheck` clean (only pre-existing SC1091 source-follow info) ✓
- Confirmed `platform::sudo` is in scope (both `. main.sh` → `platform.sh`) and survives the `log::execute` eval-in-background-subshell path ✓
- pre-commit hooks (gitleaks, trufflehog, transcrypt-check) passed ✓

_[via gantry](https://gantry.hails.info/run/sharp-mossy-thistle)_