### PR TITLE
fix(pi): repair @mariozechner migration lost in the #40/#41 merge

### DIFF
--- a/modules/pi/install.sh
+++ b/modules/pi/install.sh
@@ -4,19 +4,22 @@
 # Linux node comes from the NodeSource apt repo (modules/node), whose global
 # prefix is system-owned — npm -g needs sudo there, like the node module's own
 # pnpm fallback. macOS (brew) keeps a user-writable node bin dir.
-if platform::command_exists "pi"; then
-  log::success "pi-coding-agent"
-elif platform::is_osx; then
-  log::execute "npm install -g @earendil-works/pi-coding-agent" \
-    "pi-coding-agent"
+if ! platform::command_exists "pi"; then
+  if platform::is_osx; then
+    log::execute "npm install -g @earendil-works/pi-coding-agent" \
+      "pi-coding-agent"
+  else
+    log::execute "platform::sudo npm install -g @earendil-works/pi-coding-agent" \
+      "pi-coding-agent"
+  fi
 elif npm ls -g @mariozechner/pi-coding-agent > /dev/null 2>&1; then
   # The @mariozechner name is deprecated on npm and receives no new releases.
+  sudo_npm="$(platform::sudo_prefix)npm"
   log::execute \
-    "npm uninstall -g @mariozechner/pi-coding-agent && npm install -g @earendil-works/pi-coding-agent" \
+    "$sudo_npm uninstall -g @mariozechner/pi-coding-agent && $sudo_npm install -g @earendil-works/pi-coding-agent" \
     "pi-coding-agent (migrate to @earendil-works)"
 else
-  log::execute "platform::sudo npm install -g @earendil-works/pi-coding-agent" \
-    "pi-coding-agent"
+  log::success "pi-coding-agent"
 fi
 
 # Install pi extensions


### PR DESCRIPTION
#40 (migrate off the deprecated `@mariozechner/pi-coding-agent`) and #41 (sudo the Linux global npm install) landed concurrently; the squash of #40 onto #41's reordered conditional produced a textually-clean but semantically broken merge:

1. The migration `elif` ended up **below** the `platform::command_exists "pi"` success branch — unreachable in exactly the scenario it targets (pi already installed under the deprecated name → `log::success`, never migrates).
2. When it did fire, the `npm uninstall/install -g` ran without sudo, which EACCESes against NodeSource's system prefix on Linux (the very thing #41 fixed for fresh installs).

This reorders so the deprecated-package probe runs before declaring success, and routes the migrate through `$(platform::sudo_prefix)npm` — the existing os-aware helper (`sudo ` only on Linux non-root, empty on macOS/root), so macOS doesn't get root-owned files in its user-writable prefix.

**Verification:** `bash -n` + `shellcheck` clean (SC1091 info pre-existing); branch selection simulated for all three paths (pi absent → fresh install, deprecated pkg present → migrate, otherwise → success); gitleaks/trufflehog/transcrypt hooks passed.

_[via gantry](https://gantry.hails.info/run/fair-marble-owl)_