### PR TITLE
refactor(pi): collapse fresh-install branches via platform::sudo_prefix

### DIFF
--- a/modules/pi/install.sh
+++ b/modules/pi/install.sh
@@ -5,13 +5,8 @@
 # prefix is system-owned — npm -g needs sudo there, like the node module's own
 # pnpm fallback. macOS (brew) keeps a user-writable node bin dir.
 if ! platform::command_exists "pi"; then
-  if platform::is_osx; then
-    log::execute "npm install -g @earendil-works/pi-coding-agent" \
-      "pi-coding-agent"
-  else
-    log::execute "platform::sudo npm install -g @earendil-works/pi-coding-agent" \
-      "pi-coding-agent"
-  fi
+  log::execute "$(platform::sudo_prefix)npm install -g @earendil-works/pi-coding-agent" \
+    "pi-coding-agent"
 elif npm ls -g @mariozechner/pi-coding-agent > /dev/null 2>&1; then
   # The @mariozechner name is deprecated on npm and receives no new releases.
   sudo_npm="$(platform::sudo_prefix)npm"


### PR DESCRIPTION
Resolves the P3 finding from the [post-merge review of #43](https://github.com/DJRHails/dotfiles/pull/43#pullrequestreview-4640297484): the fresh-install `is_osx`/else split re-encoded the OS awareness `platform::sudo_prefix` already provides (empty on macOS and as root, `sudo ` on Linux non-root), leaving two sudo idioms in one file — the same dual-idiom surface that made the #40/#41 squash merge go wrong. Both branches collapse to one `$(platform::sudo_prefix)npm` line, matching the migrate branch's idiom.

**Verification:** behavior simulated identical on all four OS×EUID combinations (Linux non-root → `sudo npm`; Linux root / macOS → plain `npm`); `bash -n` + `shellcheck` clean (SC1091 info pre-existing); changed lines `shfmt -i 2` clean; gitleaks + trufflehog clean (run manually — the remote golang hooks can't bootstrap under GitHub-only egress); transcrypt pattern hook passed.

_[via gantry](https://gantry.hails.info/run/mild-cosmic-summit)_