### PR TITLE
feat(zellij): pane frames + keybind hints, per-host accent themes

### DIFF
--- a/modules/zellij/config/zellij/config.kdl
+++ b/modules/zellij/config/zellij/config.kdl
@@ -6,11 +6,16 @@ session_serialization true
 serialize_pane_viewport true
 scrollback_lines_to_serialize 10000
 
-// Keep things quiet
-pane_frames false
-simplified_ui true
-default_layout "compact"
+// Frames on, full default layout (tab bar + status bar with keybind hints —
+// still learning the binds, so keep the hints visible)
+pane_frames true
 default_mode "normal"
+
+// Per-host accent: "host" is a symlink ~/.config/zellij/themes/host.kdl ->
+// modules/zellij/config/zellij/themes/<hostname>.kdl, created by setup.sh.
+// Frame/tab colour tells you at a glance which machine a session is on
+// (bonbon=red/prod, taffy=pink, tiramisu=coffee, trifle=blue).
+theme "host"
 
 // Mouse: scroll wheel pages through scrollback, click selects pane
 mouse_mode true

--- a/modules/zellij/config/zellij/themes/bonbon.kdl
+++ b/modules/zellij/config/zellij/themes/bonbon.kdl
@@ -1,0 +1,56 @@
+// bonbon — PROD server. Red accent: the "be careful here" colour.
+// Only accent components are overridden; everything else falls back to the
+// zellij default theme (per-component fallback, zellij-utils kdl parser).
+// Numeric values are ANSI-256 indices matching zellij's DEFAULT_STYLES.
+themes {
+    host {
+        frame_selected {
+            base "#ff5555"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 201
+            emphasis_3 215
+        }
+        frame_highlight {
+            base "#ff9999"
+            background "#ff5555"
+            emphasis_0 201
+            emphasis_1 99
+            emphasis_2 "#ff5555"
+            emphasis_3 "#ff5555"
+        }
+        ribbon_selected {
+            base 16
+            background "#ff5555"
+            emphasis_0 124
+            emphasis_1 166
+            emphasis_2 201
+            emphasis_3 45
+        }
+        table_title {
+            base "#ff5555"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 "#ff5555"
+            emphasis_3 201
+        }
+        table_cell_selected {
+            base "#ff5555"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+        list_selected {
+            base "#ff5555"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+    }
+}

--- a/modules/zellij/config/zellij/themes/default.kdl
+++ b/modules/zellij/config/zellij/themes/default.kdl
@@ -1,0 +1,56 @@
+// default — fallback for hosts with no theme file of their own. Stock zellij
+// accents (green 154 / orange 166), so an unthemed host deliberately looks
+// stock: if the frames are green, this box hasn't been given a colour yet.
+// Numeric values are ANSI-256 indices matching zellij's DEFAULT_STYLES.
+themes {
+    host {
+        frame_selected {
+            base 154
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 201
+            emphasis_3 215
+        }
+        frame_highlight {
+            base 166
+            background 154
+            emphasis_0 201
+            emphasis_1 99
+            emphasis_2 154
+            emphasis_3 154
+        }
+        ribbon_selected {
+            base 16
+            background 154
+            emphasis_0 124
+            emphasis_1 166
+            emphasis_2 201
+            emphasis_3 45
+        }
+        table_title {
+            base 154
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 154
+            emphasis_3 201
+        }
+        table_cell_selected {
+            base 154
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+        list_selected {
+            base 154
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+    }
+}

--- a/modules/zellij/config/zellij/themes/taffy.kdl
+++ b/modules/zellij/config/zellij/themes/taffy.kdl
@@ -1,0 +1,56 @@
+// taffy — pink accent (salt-water taffy).
+// Only accent components are overridden; everything else falls back to the
+// zellij default theme (per-component fallback, zellij-utils kdl parser).
+// Numeric values are ANSI-256 indices matching zellij's DEFAULT_STYLES.
+themes {
+    host {
+        frame_selected {
+            base "#ff79c6"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 201
+            emphasis_3 215
+        }
+        frame_highlight {
+            base "#ffb3de"
+            background "#ff79c6"
+            emphasis_0 201
+            emphasis_1 99
+            emphasis_2 "#ff79c6"
+            emphasis_3 "#ff79c6"
+        }
+        ribbon_selected {
+            base 16
+            background "#ff79c6"
+            emphasis_0 124
+            emphasis_1 166
+            emphasis_2 201
+            emphasis_3 45
+        }
+        table_title {
+            base "#ff79c6"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 "#ff79c6"
+            emphasis_3 201
+        }
+        table_cell_selected {
+            base "#ff79c6"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+        list_selected {
+            base "#ff79c6"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+    }
+}

--- a/modules/zellij/config/zellij/themes/tiramisu.kdl
+++ b/modules/zellij/config/zellij/themes/tiramisu.kdl
@@ -1,0 +1,56 @@
+// tiramisu — coffee/amber accent (saint / Sage host).
+// Only accent components are overridden; everything else falls back to the
+// zellij default theme (per-component fallback, zellij-utils kdl parser).
+// Numeric values are ANSI-256 indices matching zellij's DEFAULT_STYLES.
+themes {
+    host {
+        frame_selected {
+            base "#d19a66"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 201
+            emphasis_3 215
+        }
+        frame_highlight {
+            base "#e8c49a"
+            background "#d19a66"
+            emphasis_0 201
+            emphasis_1 99
+            emphasis_2 "#d19a66"
+            emphasis_3 "#d19a66"
+        }
+        ribbon_selected {
+            base 16
+            background "#d19a66"
+            emphasis_0 124
+            emphasis_1 166
+            emphasis_2 201
+            emphasis_3 45
+        }
+        table_title {
+            base "#d19a66"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 "#d19a66"
+            emphasis_3 201
+        }
+        table_cell_selected {
+            base "#d19a66"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+        list_selected {
+            base "#d19a66"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+    }
+}

--- a/modules/zellij/config/zellij/themes/trifle.kdl
+++ b/modules/zellij/config/zellij/themes/trifle.kdl
@@ -1,0 +1,56 @@
+// trifle — blue accent: the local MacBook, home base.
+// Only accent components are overridden; everything else falls back to the
+// zellij default theme (per-component fallback, zellij-utils kdl parser).
+// Numeric values are ANSI-256 indices matching zellij's DEFAULT_STYLES.
+themes {
+    host {
+        frame_selected {
+            base "#61afef"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 201
+            emphasis_3 215
+        }
+        frame_highlight {
+            base "#a3d3f7"
+            background "#61afef"
+            emphasis_0 201
+            emphasis_1 99
+            emphasis_2 "#61afef"
+            emphasis_3 "#61afef"
+        }
+        ribbon_selected {
+            base 16
+            background "#61afef"
+            emphasis_0 124
+            emphasis_1 166
+            emphasis_2 201
+            emphasis_3 45
+        }
+        table_title {
+            base "#61afef"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 "#61afef"
+            emphasis_3 201
+        }
+        table_cell_selected {
+            base "#61afef"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+        list_selected {
+            base "#61afef"
+            background 238
+            emphasis_0 166
+            emphasis_1 51
+            emphasis_2 124
+            emphasis_3 201
+        }
+    }
+}

--- a/modules/zellij/setup.sh
+++ b/modules/zellij/setup.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+# shellcheck source=/dev/null
+. "$DOTFILES/scripts/core/main.sh"
+
+# Per-host zellij theme: config.kdl selects `theme "host"`, and this links
+# ~/.config/zellij/themes/host.kdl to the host-named theme file (falling back
+# to default.kdl for hosts without one). ln -sfn makes it idempotent.
+themes_src="$DOTFILES/modules/zellij/config/zellij/themes"
+host_theme="$themes_src/$(hostname -s | tr '[:upper:]' '[:lower:]').kdl"
+[ -f "$host_theme" ] || host_theme="$themes_src/default.kdl"
+
+mkdir -p "$HOME/.config/zellij/themes"
+ln -sfn "$host_theme" "$HOME/.config/zellij/themes/host.kdl"
+log::result $? "linked zellij host theme (${host_theme##*/})"


### PR DESCRIPTION
Soften the fully-quiet zellij look and add per-host accent colours.

- `pane_frames true`, default layout back (tab bar + status bar with keybind hints)
- `theme "host"` + `setup.sh`: links `~/.config/zellij/themes/host.kdl` → `themes/<hostname>.kdl` (`default.kdl` fallback = stock green, so an unthemed host is visibly unthemed)
- Accents: **bonbon = red** (prod, the careful colour) · **taffy = pink** (salt-water taffy) · **tiramisu = coffee** · **trifle = blue** (home base)
- Missing `host.kdl` is non-fatal — zellij 0.44.3 falls back to its default theme (tested live)
- Theme files override only accent components (`frame_selected`, `frame_highlight`, `ribbon_selected`, `table_title`, `table_cell_selected`, `list_selected`); everything else inherits zellij's `DEFAULT_STYLES` per-component fallback