### PR TITLE
feat: Option-as-Alt (ghostty) + stacked-by-default panes (zellij)

### DIFF
--- a/modules/ghostty/config/ghostty/config
+++ b/modules/ghostty/config/ghostty/config
@@ -5,3 +5,9 @@
 # Tradeoff: Shift+drag no longer extends selection *inside* the multiplexer —
 # native terminal selection takes over instead.
 mouse-shift-capture = never
+
+# Left Option sends Alt (ESC-prefixed), so zellij's Alt binds (Alt n new pane,
+# Alt hjkl focus, Alt +/- resize) work. `left` not `true`: the RIGHT Option key
+# keeps macOS character composition, so Option-composed symbols (#, €, dead
+# keys) still type via right Option.
+macos-option-as-alt = left

--- a/modules/zellij/config/zellij/config.kdl
+++ b/modules/zellij/config/zellij/config.kdl
@@ -25,3 +25,13 @@ scroll_buffer_size 100000
 // Don't nag about updates
 show_startup_tips false
 show_release_notes false
+
+// New panes join a stack by default (title-bar strips, focused pane expanded)
+// instead of splitting the tab into ever-smaller tiles. Directional splits are
+// still there in pane mode: Ctrl p then d (down) / r (right). Merges with the
+// default keybinds — only Alt n is overridden.
+keybinds {
+    shared_except "locked" {
+        bind "Alt n" { NewPane "stacked"; }
+    }
+}


### PR DESCRIPTION
Follow-up to #46, two small quality-of-life fixes:

- **zellij**: `Alt n` now opens panes **stacked** (title-bar strips, focused pane expanded) instead of tiling. Directional splits remain on `Ctrl p d`/`r`. Keybind block merges with defaults — only `Alt n` overridden. Verified on 0.44.3 with synthetic `Alt+n` in a scratch session.
- **ghostty**: `macos-option-as-alt = left` — macOS was composing special characters on Option, so zellij never saw any Alt binds. Left Option = Alt; right Option keeps character composition (#, dead keys).