### PR TITLE
feat(zellij): grid-then-stack default layout, revert Alt-n stacked bind

### DIFF
--- a/modules/zellij/config/zellij/config.kdl
+++ b/modules/zellij/config/zellij/config.kdl
@@ -22,16 +22,12 @@ mouse_mode true
 copy_on_select true
 scroll_buffer_size 100000
 
+// Tile normally up to a 2x2 grid; past four panes the bottom-right cell
+// becomes a stack absorbing the overflow (see layouts/grid-then-stack.kdl,
+// shared via the ~/.config/zellij/layouts symlink). Alt n just follows the
+// active swap layout; Alt [ / ] switches to a focus-plus-stack arrangement.
+default_layout "grid-then-stack"
+
 // Don't nag about updates
 show_startup_tips false
 show_release_notes false
-
-// New panes join a stack by default (title-bar strips, focused pane expanded)
-// instead of splitting the tab into ever-smaller tiles. Directional splits are
-// still there in pane mode: Ctrl p then d (down) / r (right). Merges with the
-// default keybinds — only Alt n is overridden.
-keybinds {
-    shared_except "locked" {
-        bind "Alt n" { NewPane "stacked"; }
-    }
-}

--- a/modules/zellij/config/zellij/layouts/grid-then-stack.kdl
+++ b/modules/zellij/config/zellij/layouts/grid-then-stack.kdl
@@ -1,0 +1,72 @@
+// Default layout: tile normally up to a 2x2 grid, then stop shrinking —
+// the bottom-right cell becomes a stack that absorbs every further pane
+// (title-bar strips, focused one expanded). Alt [ / ] swaps to the stock
+// "focus + stack" arrangement when a big main pane is wanted.
+layout {
+    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="tab-bar"
+        }
+        children
+        pane size=1 borderless=true {
+            plugin location="status-bar"
+        }
+    }
+
+    tab
+
+    swap_tiled_layout name="grid-then-stack" {
+        tab max_panes=2 {
+            pane split_direction="vertical" {
+                pane
+                pane { children; }
+            }
+        }
+        tab max_panes=3 {
+            pane split_direction="vertical" {
+                pane
+                pane split_direction="horizontal" {
+                    pane
+                    pane { children; }
+                }
+            }
+        }
+        tab max_panes=4 {
+            pane split_direction="horizontal" {
+                pane split_direction="vertical" {
+                    pane
+                    pane
+                }
+                pane split_direction="vertical" {
+                    pane
+                    pane { children; }
+                }
+            }
+        }
+        tab {
+            pane split_direction="horizontal" {
+                pane split_direction="vertical" {
+                    pane
+                    pane
+                }
+                pane split_direction="vertical" {
+                    pane
+                    pane stacked=true { children; }
+                }
+            }
+        }
+    }
+
+    swap_tiled_layout name="focus-plus-stack" {
+        tab min_panes=2 {
+            pane split_direction="vertical" {
+                pane
+                pane stacked=true { children; }
+            }
+        }
+    }
+
+    swap_floating_layout name="staggered" {
+        floating_panes
+    }
+}

--- a/modules/zellij/symlinks.conf
+++ b/modules/zellij/symlinks.conf
@@ -1,1 +1,2 @@
 config/zellij/config.kdl -> ~/.config/zellij/config.kdl
+config/zellij/layouts -> ~/.config/zellij/layouts


### PR DESCRIPTION
Tiling policy instead of a keybind: panes tile normally up to a 2x2 grid,
then the bottom-right cell becomes a stack absorbing every further pane
(swap layout, so plain Alt n / new-pane follows it). Alt [ / ] switches to
a focus-plus-stack arrangement. Verified the 6-pane progression on 0.44.3
via zellij action new-pane in a scratch session.

Reverts the Alt n -> NewPane stacked override from #47 — always-stacked
was the wrong default; the grid is better until it gets crowded.
