### PR TITLE
feat(pi): add @ff-labs/pi-fff extension to package set

### DIFF
--- a/modules/pi/install.sh
+++ b/modules/pi/install.sh
@@ -35,4 +35,8 @@ if platform::command_exists "pi"; then
   log::execute \
     "pi install git:github.com/picassio/pi-cc-patch" \
     "pi-cc-patch"
+
+  log::execute \
+    "pi install npm:@ff-labs/pi-fff" \
+    "pi-fff"
 fi

--- a/modules/pi/settings.json
+++ b/modules/pi/settings.json
@@ -3,9 +3,10 @@
     "git:github.com/DJRHails/pi-interactive-subagents",
     "git:github.com/DJRHails/pi-smart-sessions",
     "npm:pi-multi-pass",
-    "git:github.com/picassio/pi-cc-patch"
+    "git:github.com/picassio/pi-cc-patch",
+    "npm:@ff-labs/pi-fff"
   ],
-  "lastChangelogVersion": "0.80.3",
+  "lastChangelogVersion": "0.80.6",
   "defaultProvider": "anthropic-api",
   "defaultModel": "claude-opus-4-8[fast]",
   "defaultThinkingLevel": "xhigh",


### PR DESCRIPTION
Adds `npm:@ff-labs/pi-fff` to the pi module — both the `install.sh` bootstrap and the canonical `packages` list in `settings.json` (symlinked to `~/.pi/agent/settings.json`).

Verified locally: `pi install npm:@ff-labs/pi-fff` succeeds and the package persists in settings.