### PR TITLE
pi: install @narumitw/pi-goal extension

### DIFF
--- a/modules/pi/install.sh
+++ b/modules/pi/install.sh
@@ -39,4 +39,8 @@ if platform::command_exists "pi"; then
   log::execute \
     "pi install npm:@ff-labs/pi-fff" \
     "pi-fff"
+
+  log::execute \
+    "pi install npm:@narumitw/pi-goal" \
+    "pi-goal"
 fi

--- a/modules/pi/settings.json
+++ b/modules/pi/settings.json
@@ -4,7 +4,8 @@
     "git:github.com/DJRHails/pi-smart-sessions",
     "npm:pi-multi-pass",
     "git:github.com/DJRHails/pi-cc-patch",
-    "npm:@ff-labs/pi-fff"
+    "npm:@ff-labs/pi-fff",
+    "npm:@narumitw/pi-goal"
   ],
   "lastChangelogVersion": "0.80.6",
   "defaultProvider": "anthropic-api",


### PR DESCRIPTION
Adds the [`@narumitw/pi-goal`](https://www.npmjs.com/package/@narumitw/pi-goal) pi extension (v0.13.1 — keeps working on a `/goal` until the agent marks it complete) to the canonical package set: `pi install npm:@narumitw/pi-goal` in `modules/pi/install.sh`, mirrored in `modules/pi/settings.json` `packages`.