### PR TITLE
Shell startup caching + zellij session GC

### DIFF
--- a/modules/zellij/auto-attach.zsh
+++ b/modules/zellij/auto-attach.zsh
@@ -158,6 +158,13 @@
     # app surface regardless of the stale env. The picker re-attach path writes this too.
     { print -r -- "${CMUX_WORKSPACE_ID} ${CMUX_SURFACE_ID}" > "$logdir/live-$session" } 2>/dev/null
 
+    # Reap leaked sessions in the background (throttled to once per 6h inside
+    # the script) so tab churn can't re-accumulate hundreds of idle servers.
+    local gc_script="${DOTFILES:-$HOME/.files}/modules/zellij/zellij-gc"
+    if [[ -x $gc_script ]]; then
+        zsh -f "$gc_script" >/dev/null 2>&1 &!
+    fi
+
     local short_tmp="/tmp"
     [[ -d $short_tmp ]] || short_tmp="$TMPDIR"
 

--- a/modules/zellij/zellij-gc
+++ b/modules/zellij/zellij-gc
@@ -1,0 +1,117 @@
+#!/usr/bin/env zsh
+# Garbage-collect leaked cmux zellij sessions.
+#
+# cmux re-mints workspace/surface UUIDs on every app restart, so auto-attach
+# (auto-attach.zsh) creates a fresh session per surface and the old ones stay
+# behind as live-but-unattached servers. Each zellij server polls
+# `ps -ao ppid,args` for session serialization, so a few weeks of tab churn
+# (observed: 137 live servers) drives system load high enough that new ptys
+# take seconds to spawn. This script reaps them; auto-attach spawns it in the
+# background, throttled by a stamp file.
+#
+# Only touches sessions named cmux-* . A session is reaped when it is:
+#   - not attached (no `zellij attach <name>` client process), and
+#   - idle (no pane shell has a child process other than ps), and
+#   - stale (its auto-attach stamp $logdir/last-<name> is older than
+#     $CMUX_ZELLIJ_GC_STALE_HOURS, default 48; missing stamp counts as stale).
+# Reaped live sessions get SIGTERM — serialized state stays on disk, so they
+# remain resurrectable. EXITED session records older than 7 days are deleted.
+#
+# Usage: zellij-gc [--dry-run] [--force]
+#   --dry-run  print what would be reaped, change nothing
+#   --force    ignore the 6h throttle stamp
+
+set -u
+zmodload zsh/datetime
+
+dry_run=0 force=0
+for arg in "$@"; do
+  case $arg in
+    --dry-run) dry_run=1 ;;
+    --force) force=1 ;;
+    *) print -u2 "zellij-gc: unknown flag $arg"; exit 2 ;;
+  esac
+done
+
+logdir="${XDG_CACHE_HOME:-$HOME/.cache}/cmux-zellij"
+gc_log="$logdir/gc.log"
+throttle_stamp="$logdir/gc-last-run"
+stale_hours="${CMUX_ZELLIJ_GC_STALE_HOURS:-48}"
+exited_max_days=7
+
+mkdir -p "$logdir" 2>/dev/null || exit 0
+
+log() {
+  print -r -- "$(strftime '%Y-%m-%d %H:%M:%S' $EPOCHSECONDS) $*" >> "$gc_log" 2>/dev/null
+  (( dry_run )) && print -r -- "$*"
+}
+
+# Throttle: bail if we ran within the last 6 hours (unless --force / --dry-run).
+if (( ! force && ! dry_run )) && [[ -n $throttle_stamp(#qN.mh-6) ]]; then
+  exit 0
+fi
+(( dry_run )) || print $EPOCHSECONDS > "$throttle_stamp"
+
+command -v zellij >/dev/null 2>&1 || exit 0
+
+# Sessions with an attach client anywhere on this machine are in active use.
+typeset -A protected
+for name in $(ps -eo args 2>/dev/null | grep -E 'zellij attach' | grep -v grep \
+    | sed -E 's/.*attach (-c )?//' | awk '{print $1}'); do
+  protected[$name]=1
+done
+[[ -n ${ZELLIJ_SESSION_NAME:-} ]] && protected[$ZELLIJ_SESSION_NAME]=1
+
+now=$EPOCHSECONDS
+stale_before=$(( now - stale_hours * 3600 ))
+reaped=0
+
+# Reap live-but-unattached idle stale servers.
+ps -eo pid,args 2>/dev/null | grep 'zellij --server' | grep -v grep | while read -r pid args; do
+  sess="${args##*/}"
+  [[ $sess == cmux-* ]] || continue
+  [[ -n ${protected[$sess]:-} ]] && continue
+
+  # busy check: any pane shell with a non-ps child means real work is running
+  busy=0
+  for shell_pid in $(pgrep -P "$pid" 2>/dev/null); do
+    for job in $(pgrep -P "$shell_pid" 2>/dev/null); do
+      [[ "$(ps -p "$job" -o comm= 2>/dev/null)" == ps ]] && continue
+      busy=1; break 2
+    done
+  done
+  (( busy )) && continue
+
+  # stale check via auto-attach's per-session stamp
+  stamp="$logdir/last-$sess"
+  if [[ -f $stamp ]]; then
+    last=$(<"$stamp") 2>/dev/null
+    [[ $last == <-> ]] && (( last > stale_before )) && continue
+  fi
+
+  if (( dry_run )); then
+    log "would-reap live sess=$sess pid=$pid"
+  else
+    kill -TERM "$pid" 2>/dev/null && log "reaped live sess=$sess pid=$pid"
+  fi
+  (( reaped++ ))
+done
+
+# Delete EXITED cmux-* records whose stamp is older than $exited_max_days.
+exited_before=$(( now - exited_max_days * 86400 ))
+for sess in $(zellij list-sessions 2>/dev/null | perl -pe 's/\e\[[0-9;]*m//g' \
+    | grep EXITED | awk '{print $1}'); do
+  [[ $sess == cmux-* ]] || continue
+  stamp="$logdir/last-$sess"
+  if [[ -f $stamp ]]; then
+    last=$(<"$stamp") 2>/dev/null
+    [[ $last == <-> ]] && (( last > exited_before )) && continue
+  fi
+  if (( dry_run )); then
+    log "would-delete exited sess=$sess"
+  else
+    zellij delete-session "$sess" >/dev/null 2>&1 && log "deleted exited sess=$sess"
+  fi
+done
+
+exit 0

--- a/modules/zsh/sheldon.zsh
+++ b/modules/zsh/sheldon.zsh
@@ -6,4 +6,6 @@ if (( ! $+functions[compdef] )); then
   compdef() { __deferred_compdefs+=("${(j: :)@}") }
 fi
 
-eval "$(sheldon source)"
+# Cached: `sheldon source` spawns a ~90ms subprocess but its output only
+# changes when the binary or plugins.toml does.
+_cached_eval -d "${XDG_CONFIG_HOME:-$HOME/.config}/sheldon/plugins.toml" sheldon source

--- a/modules/zsh/symlinks.conf
+++ b/modules/zsh/symlinks.conf
@@ -1,5 +1,6 @@
 zshrc -> ~/.zshrc
 zshrc.local -> ~/.zshrc.local
 zshenv -> ~/.zshenv
+zprofile -> ~/.zprofile
 starship.toml -> ~/.config/starship.toml
 config/sheldon/plugins.toml -> ~/.config/sheldon/plugins.toml

--- a/modules/zsh/zprofile
+++ b/modules/zsh/zprofile
@@ -1,0 +1,13 @@
+# Homebrew environment, cached via _cached_eval (zshenv) — `brew shellenv`
+# output is static exports but the subprocess costs ~40ms per login shell.
+# Probe the standard prefixes: Apple Silicon, Intel macOS, Linuxbrew.
+for _brew in /opt/homebrew/bin/brew /usr/local/bin/brew /home/linuxbrew/.linuxbrew/bin/brew; do
+  [[ -x $_brew ]] || continue
+  if (( $+functions[_cached_eval] )); then
+    _cached_eval "$_brew" shellenv
+  else
+    eval "$("$_brew" shellenv)"
+  fi
+  break
+done
+unset _brew

--- a/modules/zsh/zshenv
+++ b/modules/zsh/zshenv
@@ -15,6 +15,67 @@ done
 # (scripts, `zsh -c`, Claude Code's tool shell) — not just interactive ones.
 disable log 2>/dev/null
 
+# _cached_eval [-d dep_file]... cmd [args...]
+#
+# Source `cmd args...` output through an on-disk cache so startup skips the
+# subprocess (each `eval "$(tool init zsh)"` costs 20-90ms). The cache header
+# records the resolved binary's mtime+size, so upgrades regenerate it even
+# when the new binary's mtime is older (Homebrew bottles do this); `-d` files
+# (e.g. a plugins.toml) invalidate on their mtime. Writes are atomic
+# (tmp + mv) so concurrent shells never source a half-written cache, and any
+# cache-layer failure — unwritable dir, corrupt file — falls back to a live
+# `eval "$(cmd ...)"`, so caching can never change shell behaviour. Returns 1
+# only when the command itself is missing. In .zshenv so zprofile and
+# zshrc.local can use it too.
+_cached_eval() {
+  emulate -L zsh
+  local -a deps
+  while [[ $1 == -d ]]; do
+    deps+=("$2")
+    shift 2
+  done
+  local bin="${commands[$1]:-$1}"
+  [[ -x $bin ]] || return 1
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/zsh-eval-cache"
+  local cache="$cache_dir/${${(j:-:)@}//\//_}.zsh"
+
+  zmodload -F zsh/stat b:zstat 2>/dev/null
+  local -A binstat
+  local header=''
+  if zstat -H binstat -- "$bin" 2>/dev/null; then
+    header="# _cached_eval: $bin mtime=$binstat[mtime] size=$binstat[size]"
+  fi
+
+  local fresh=0 first_line='' dep
+  if [[ -n $header && -s $cache ]]; then
+    IFS= read -r first_line < "$cache" 2>/dev/null
+    if [[ $first_line == "$header" ]]; then
+      fresh=1
+      for dep in "${deps[@]}"; do
+        [[ -e $dep && $dep -nt $cache ]] && { fresh=0; break }
+      done
+    fi
+  fi
+
+  if (( ! fresh )); then
+    local tmp="$cache.$$.tmp"
+    if ! { command mkdir -p -- "$cache_dir" \
+        && builtin print -r -- "$header" > "$tmp" \
+        && "$@" >> "$tmp" \
+        && command mv -f -- "$tmp" "$cache" } 2>/dev/null; then
+      command rm -f -- "$tmp" 2>/dev/null
+      eval "$("$@")"
+      return
+    fi
+  fi
+
+  if ! builtin source "$cache"; then
+    command rm -f -- "$cache" 2>/dev/null
+    eval "$("$@")"
+  fi
+}
+
 [[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
 
 [[ -d "$HOME/.foundry/bin" ]] && export PATH="$PATH:$HOME/.foundry/bin"

--- a/modules/zsh/zshrc.tmpl
+++ b/modules/zsh/zshrc.tmpl
@@ -12,9 +12,11 @@ then
   source ~/.zshrc.local
 fi
 
-# all of our zsh files
+# all of our zsh files — modules keep their zsh at modules/<name>/<file>.zsh,
+# so a fixed-depth glob suffices; the recursive `**` walk of the whole repo
+# (agents/skills trees etc.) costs ~50ms per shell.
 typeset -U config_files
-config_files=($DOTFILES/**/*.zsh)
+config_files=($DOTFILES/modules/*/*.zsh(N))
 
 # Drop transcrypt-encrypted files that haven't been decrypted on this host (no
 # crypt key configured). Their working-tree content is base64 ciphertext that
@@ -58,7 +60,13 @@ freload $^fpath/*(N-.x:t)
 
 # initialize autocomplete here, otherwise functions won't be loaded
 autoload -U compinit
-compinit
+# Full compinit (with compaudit) at most once every 24 hours; -C trusts the
+# existing dump file and skips the ~60ms audit on every other shell.
+if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
+  compinit
+else
+  compinit -C
+fi
 
 # replay compdef calls queued by plugins loaded before compinit (see sheldon.zsh)
 for d in $__deferred_compdefs
@@ -87,5 +95,5 @@ bindkey "^[[B" down-line-or-beginning-search # Down
 # Add bin to path
 export PATH=${PATH:+$PATH:}${DOTFILES}/bin
 
-# Starship prompt
-(( $+commands[starship] )) && eval "$(starship init zsh)"
+# Starship prompt (cached: skips the ~40ms init subprocess; see zshenv)
+(( $+commands[starship] )) && _cached_eval starship init zsh


### PR DESCRIPTION
## What

Two fixes for slow time-to-first-prompt (new terminal tabs took 1.5-3s on trifle):

**perf(zsh)** — `_cached_eval` helper in zshenv caches `eval "$(tool init zsh)"` output on disk (binary mtime+size keyed, atomic writes, live-eval fallback on any cache failure). Applied to sheldon, starship, and brew shellenv — the latter via a new tracked `zprofile` that probes Apple Silicon / Intel / Linuxbrew prefixes. Fixed-depth module glob and daily-instead-of-every-shell compinit audit. Warm interactive startup: ~1.3s → ~0.17s.

**feat(zellij)** — cmux tab churn leaked live-but-unattached zellij servers (observed: 137, each polling `ps -ao ppid,args`, driving load average to 58). New `zellij-gc` reaps `cmux-*` sessions that are unattached + idle + stale, deletes week-old EXITED records, self-throttles to one run per 6h, and is spawned disowned from auto-attach. Supports `--dry-run` / `--force`.

## Testing

- Behavior suite on `_cached_eval`: cold/warm/binary-upgrade/dep-file invalidation, corrupt-cache recovery, missing binary, read-only cache dir, 6-way concurrent cold start (no torn reads)
- `zellij-gc` falsification test: deliberately leaked a session, dry-run flags it, real run reaps it; attached/busy sessions untouched
- End-to-end pty measurement: cmux→zellij→prompt chain 1.3-2.7s → ~0.55s

Note: the machine-local `modules/zsh/zshrc` (gitignored) also got lazy-loaded nvm; other machines keep their local zshrc, and new renders inherit the template changes.