### PR TITLE
fix(git): gitignore nesting follow-up from PR #53 review

### DIFF
--- a/modules/git/gitignore
+++ b/modules/git/gitignore
@@ -77,6 +77,5 @@ log/*.log
 # ----------------------------------------------------------------------
 
 .agents/worktrees/
-.agents/settings.local.json
-.claude/settings.local.json
+**/.agents/settings.local.json
 **/.claude/settings.local.json


### PR DESCRIPTION
Follow-up to the post-merge review of #53 (findings F1/F2 posted inline there):

- **F1 — redundant pattern:** removed the root-anchored `.claude/settings.local.json` line — `**/.claude/settings.local.json` already covers it (`**/` matches zero directories).
- **F2 — sibling gap:** `.agents/settings.local.json` → `**/.agents/settings.local.json`, so nested copies are ignored too, matching the `.claude` treatment.

Verified with `git check-ignore -v`: root and nested `settings.local.json` under both `.agents/` and `.claude/` all match. gitleaks (staged) + trufflehog (filesystem) clean; local check-crypt-patterns hook passed.

_[via gantry](https://gantry.hails.info/run/amber-zesty-alder)_