### PR TITLE
fix: resolve review findings for PR #54 — shell startup caching + zellij GC

### DIFF
--- a/modules/zellij/auto-attach.zsh
+++ b/modules/zellij/auto-attach.zsh
@@ -201,6 +201,12 @@
         eval "exec ${hop}"
     fi
 
+    # Refresh the stamp on detach: zellij-gc reads it as "when did this session
+    # last have a user", so a just-detached session gets the full stale window
+    # before becoming reap-eligible (the attach-time write above would already
+    # be old after a long attached stretch).
+    { date +%s > "$stamp" } 2>/dev/null
+
     # Intentionally NOT `exec`: on detach (Ctrl+O d / `zellij action detach`) or
     # quit, control returns here, the rest of zshrc runs, and you land in a plain
     # non-zellij shell in the SAME surface instead of the window closing.

--- a/modules/zellij/zellij-gc
+++ b/modules/zellij/zellij-gc
@@ -11,17 +11,23 @@
 #
 # Only touches sessions named cmux-* . A session is reaped when it is:
 #   - not attached (no `zellij attach <name>` client process), and
-#   - idle (no pane shell has a child process other than ps), and
+#   - idle (every server child is a plain shell, and no pane shell has a
+#     child process other than ps), and
 #   - stale (its auto-attach stamp $logdir/last-<name> is older than
 #     $CMUX_ZELLIJ_GC_STALE_HOURS, default 48; missing stamp counts as stale).
 # Reaped live sessions get SIGTERM — serialized state stays on disk, so they
-# remain resurrectable. EXITED session records older than 7 days are deleted.
+# remain resurrectable — and their stamp is reset so the EXITED sweep below
+# won't delete them for another $exited_max_days. EXITED records are deleted
+# once their stamp is older than 7 days; a record with no usable stamp gets
+# one seeded now, so deletion happens no earlier than 7 days after first
+# sighting.
 #
 # Usage: zellij-gc [--dry-run] [--force]
-#   --dry-run  print what would be reaped, change nothing
+#   --dry-run  print what would be reaped; touches no sessions, stamps, or logs
 #   --force    ignore the 6h throttle stamp
 
 set -u
+setopt extended_glob  # (#q...) glob qualifiers below are inert without this
 zmodload zsh/datetime
 
 dry_run=0 force=0
@@ -37,13 +43,17 @@ logdir="${XDG_CACHE_HOME:-$HOME/.cache}/cmux-zellij"
 gc_log="$logdir/gc.log"
 throttle_stamp="$logdir/gc-last-run"
 stale_hours="${CMUX_ZELLIJ_GC_STALE_HOURS:-48}"
+[[ $stale_hours == <-> ]] || stale_hours=48
 exited_max_days=7
 
 mkdir -p "$logdir" 2>/dev/null || exit 0
 
 log() {
-  print -r -- "$(strftime '%Y-%m-%d %H:%M:%S' $EPOCHSECONDS) $*" >> "$gc_log" 2>/dev/null
-  (( dry_run )) && print -r -- "$*"
+  if (( dry_run )); then
+    print -r -- "$*"
+  else
+    print -r -- "$(strftime '%Y-%m-%d %H:%M:%S' $EPOCHSECONDS) $*" >> "$gc_log" 2>/dev/null
+  fi
 }
 
 # Throttle: bail if we ran within the last 6 hours (unless --force / --dry-run).
@@ -72,9 +82,17 @@ ps -eo pid,args 2>/dev/null | grep 'zellij --server' | grep -v grep | while read
   [[ $sess == cmux-* ]] || continue
   [[ -n ${protected[$sess]:-} ]] && continue
 
-  # busy check: any pane shell with a non-ps child means real work is running
+  # busy check: a direct server child that isn't a plain shell is a command
+  # pane (`zellij run -- cmd`, an exec'd program) — real work even with no
+  # children. For shell children, any non-ps grandchild means a running job.
   busy=0
   for shell_pid in $(pgrep -P "$pid" 2>/dev/null); do
+    child_comm="${$(ps -p "$shell_pid" -o comm= 2>/dev/null):t}"
+    case ${child_comm#-} in
+      zsh|bash|fish|sh|dash) ;;
+      '') continue ;;  # vanished between pgrep and ps; nothing to inspect
+      *) busy=1; break ;;
+    esac
     for job in $(pgrep -P "$shell_pid" 2>/dev/null); do
       [[ "$(ps -p "$job" -o comm= 2>/dev/null)" == ps ]] && continue
       busy=1; break 2
@@ -91,27 +109,45 @@ ps -eo pid,args 2>/dev/null | grep 'zellij --server' | grep -v grep | while read
 
   if (( dry_run )); then
     log "would-reap live sess=$sess pid=$pid"
-  else
-    kill -TERM "$pid" 2>/dev/null && log "reaped live sess=$sess pid=$pid"
+  elif kill -TERM "$pid" 2>/dev/null; then
+    # Reset the stamp so the EXITED sweep below treats the reap as t=0 and
+    # keeps the serialized state resurrectable for $exited_max_days.
+    print $EPOCHSECONDS > "$stamp" 2>/dev/null
+    log "reaped live sess=$sess pid=$pid"
   fi
   (( reaped++ ))
 done
 
 # Delete EXITED cmux-* records whose stamp is older than $exited_max_days.
+# A record with no usable stamp (predates the gc, or only ever attached via
+# the mosh/durable paths which bypass auto-attach) gets one seeded now, so
+# it is deleted no earlier than $exited_max_days from first sighting.
 exited_before=$(( now - exited_max_days * 86400 ))
+deleted=0
 for sess in $(zellij list-sessions 2>/dev/null | perl -pe 's/\e\[[0-9;]*m//g' \
     | grep EXITED | awk '{print $1}'); do
   [[ $sess == cmux-* ]] || continue
   stamp="$logdir/last-$sess"
-  if [[ -f $stamp ]]; then
-    last=$(<"$stamp") 2>/dev/null
-    [[ $last == <-> ]] && (( last > exited_before )) && continue
+  last=''
+  [[ -f $stamp ]] && last=$(<"$stamp") 2>/dev/null
+  if [[ $last != <-> ]]; then
+    if (( dry_run )); then
+      log "would-seed stamp for exited sess=$sess"
+    else
+      print $EPOCHSECONDS > "$stamp" 2>/dev/null
+      log "seeded stamp for exited sess=$sess"
+    fi
+    continue
   fi
+  (( last > exited_before )) && continue
   if (( dry_run )); then
     log "would-delete exited sess=$sess"
   else
     zellij delete-session "$sess" >/dev/null 2>&1 && log "deleted exited sess=$sess"
   fi
+  (( deleted++ ))
 done
+
+log "run complete reaped=$reaped deleted=$deleted"
 
 exit 0

--- a/modules/zsh/sheldon.zsh
+++ b/modules/zsh/sheldon.zsh
@@ -8,4 +8,8 @@ fi
 
 # Cached: `sheldon source` spawns a ~90ms subprocess but its output only
 # changes when the binary or plugins.toml does.
-_cached_eval -d "${XDG_CONFIG_HOME:-$HOME/.config}/sheldon/plugins.toml" sheldon source
+if (( $+commands[sheldon] )); then
+  _cached_eval -d "${XDG_CONFIG_HOME:-$HOME/.config}/sheldon/plugins.toml" sheldon source
+else
+  print -u2 "warning: sheldon not installed; zsh plugins skipped"
+fi

--- a/modules/zsh/zprofile
+++ b/modules/zsh/zprofile
@@ -1,13 +1,18 @@
-# Homebrew environment, cached via _cached_eval (zshenv) — `brew shellenv`
-# output is static exports but the subprocess costs ~40ms per login shell.
-# Probe the standard prefixes: Apple Silicon, Intel macOS, Linuxbrew.
-for _brew in /opt/homebrew/bin/brew /usr/local/bin/brew /home/linuxbrew/.linuxbrew/bin/brew; do
-  [[ -x $_brew ]] || continue
-  if (( $+functions[_cached_eval] )); then
-    _cached_eval "$_brew" shellenv
-  else
-    eval "$("$_brew" shellenv)"
-  fi
-  break
-done
-unset _brew
+# Homebrew environment, cached via _cached_eval (zshenv). `brew shellenv`
+# output depends on the environment at generation time — modern brew prints
+# (almost) nothing when HOMEBREW_PREFIX is already exported — so only run,
+# and only cache, from shells that don't already have brew configured;
+# nested login shells inherit the exports anyway. Probe the standard
+# prefixes: Apple Silicon, Intel macOS, Linuxbrew.
+if [[ -z ${HOMEBREW_PREFIX:-} ]]; then
+  for _brew in /opt/homebrew/bin/brew /usr/local/bin/brew /home/linuxbrew/.linuxbrew/bin/brew; do
+    [[ -x $_brew ]] || continue
+    if (( $+functions[_cached_eval] )); then
+      _cached_eval "$_brew" shellenv
+    else
+      eval "$("$_brew" shellenv)"
+    fi
+    break
+  done
+  unset _brew
+fi

--- a/modules/zsh/zshenv
+++ b/modules/zsh/zshenv
@@ -19,18 +19,22 @@ disable log 2>/dev/null
 #
 # Source `cmd args...` output through an on-disk cache so startup skips the
 # subprocess (each `eval "$(tool init zsh)"` costs 20-90ms). The cache header
-# records the resolved binary's mtime+size, so upgrades regenerate it even
-# when the new binary's mtime is older (Homebrew bottles do this); `-d` files
-# (e.g. a plugins.toml) invalidate on their mtime. Writes are atomic
+# records the argv plus the resolved binary's mtime+size, so upgrades
+# regenerate it even when the new binary's mtime is older (Homebrew bottles
+# do this) and distinct invocations can't collide on one cache file; `-d`
+# files (e.g. a plugins.toml) invalidate on their mtime. Writes are atomic
 # (tmp + mv) so concurrent shells never source a half-written cache, and any
 # cache-layer failure — unwritable dir, corrupt file — falls back to a live
-# `eval "$(cmd ...)"`, so caching can never change shell behaviour. Returns 1
-# only when the command itself is missing. In .zshenv so zprofile and
-# zshrc.local can use it too.
+# `eval "$(cmd ...)"`. Deliberately no `emulate -L`: the sourced output must
+# run under the caller's options, with its own `setopt`/`typeset` landing at
+# global scope (starship emits `setopt promptsubst`), exactly like the
+# top-level eval it replaces. Only cache-layer errors are suppressed — the
+# command's own stderr stays visible. Returns 1 when the command is missing,
+# else the sourced output's status. In .zshenv so zprofile and zshrc.local
+# can use it too.
 _cached_eval() {
-  emulate -L zsh
   local -a deps
-  while [[ $1 == -d ]]; do
+  while [[ ${1-} == -d ]]; do
     deps+=("$2")
     shift 2
   done
@@ -44,7 +48,7 @@ _cached_eval() {
   local -A binstat
   local header=''
   if zstat -H binstat -- "$bin" 2>/dev/null; then
-    header="# _cached_eval: $bin mtime=$binstat[mtime] size=$binstat[size]"
+    header="# _cached_eval: ${(j: :)@} -> $bin mtime=$binstat[mtime] size=$binstat[size]"
   fi
 
   local fresh=0 first_line='' dep
@@ -61,9 +65,9 @@ _cached_eval() {
   if (( ! fresh )); then
     local tmp="$cache.$$.tmp"
     if ! { command mkdir -p -- "$cache_dir" \
-        && builtin print -r -- "$header" > "$tmp" \
-        && "$@" >> "$tmp" \
-        && command mv -f -- "$tmp" "$cache" } 2>/dev/null; then
+        && builtin print -r -- "$header" > "$tmp" } 2>/dev/null \
+        || ! "$@" >> "$tmp" \
+        || ! command mv -f -- "$tmp" "$cache" 2>/dev/null; then
       command rm -f -- "$tmp" 2>/dev/null
       eval "$("$@")"
       return

--- a/modules/zsh/zshrc.tmpl
+++ b/modules/zsh/zshrc.tmpl
@@ -61,12 +61,21 @@ freload $^fpath/*(N-.x:t)
 # initialize autocomplete here, otherwise functions won't be loaded
 autoload -U compinit
 # Full compinit (with compaudit) at most once every 24 hours; -C trusts the
-# existing dump file and skips the ~60ms audit on every other shell.
-if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
-  compinit
-else
-  compinit -C
-fi
+# existing dump file and skips the ~60ms audit on every other shell. In an
+# anonymous function because (#q) glob qualifiers need extended_glob, which
+# must stay off in the interactive shell (it changes glob semantics), and
+# because compinit leaves an up-to-date dump's mtime alone — the touch is
+# what actually advances the 24h clock.
+() {
+  setopt localoptions extendedglob
+  local dump="${ZDOTDIR:-$HOME}/.zcompdump"
+  if [[ -n $dump(#qN.mh-24) ]]; then
+    compinit -C
+  else
+    compinit
+    [[ -f $dump ]] && touch "$dump"
+  fi
+}
 
 # replay compdef calls queued by plugins loaded before compinit (see sheldon.zsh)
 for d in $__deferred_compdefs

--- a/tests/cached-eval.test.zsh
+++ b/tests/cached-eval.test.zsh
@@ -1,0 +1,97 @@
+#!/usr/bin/env zsh
+# Behavior suite for _cached_eval (modules/zsh/zshenv).
+# Self-contained: `zsh -f tests/cached-eval.test.zsh`. Exits non-zero on failure.
+set -u
+
+script_dir="${0:A:h}"
+zshenv="$script_dir/../modules/zsh/zshenv"
+
+work="$(mktemp -d)"
+trap 'rm -rf -- "$work"' EXIT
+export XDG_CACHE_HOME="$work/cache"
+mkdir -p "$work/bin"
+path=("$work/bin" $path)
+
+# Fake tool: emits its invocation count, so a cache hit (tool NOT re-run) is
+# distinguishable from a regeneration (count advances).
+export FAKETOOL_COUNT_FILE="$work/count"
+cat > "$work/bin/faketool" <<'EOF'
+#!/bin/sh
+count=$(cat "$FAKETOOL_COUNT_FILE" 2>/dev/null || echo 0)
+echo "export FAKE_COUNT=$count"
+echo $((count + 1)) > "$FAKETOOL_COUNT_FILE"
+EOF
+chmod +x "$work/bin/faketool"
+echo 0 > "$FAKETOOL_COUNT_FILE"
+
+fails=0
+check() {
+  if [[ $2 == "$3" ]]; then
+    print "ok   $1"
+  else
+    print "FAIL $1: expected [$2] got [$3]"
+    (( fails++ ))
+  fi
+}
+
+# Run a snippet in a fresh non-rc shell with only _cached_eval defined, so the
+# suite exercises the function exactly as a cold shell would see it.
+fn="$(sed -n '/^_cached_eval() {/,/^}/p' "$zshenv")"
+run() { zsh -f -c "$fn"$'\n'"$1" }
+
+cache_file="$XDG_CACHE_HOME/zsh-eval-cache/faketool.zsh"
+
+# cold start: tool runs once, output is evaluated
+check cold "0" "$(run '_cached_eval faketool && print $FAKE_COUNT')"
+# warm start: cache hit, tool must NOT run again
+check warm "0" "$(run '_cached_eval faketool && print $FAKE_COUNT')"
+check warm-no-subprocess "1" "$(<"$FAKETOOL_COUNT_FILE")"
+
+# binary upgrade (mtime change) regenerates
+sleep 1.1; touch "$work/bin/faketool"
+check binary-upgrade "1" "$(run '_cached_eval faketool && print $FAKE_COUNT')"
+
+# -d dep file: older dep leaves the cache fresh, newer dep invalidates
+dep="$work/plugins.toml"
+touch -r "$zshenv" "$dep"  # mtime well before the cache's
+check dep-old-fresh "1" "$(run "_cached_eval -d ${(q)dep} faketool && print \$FAKE_COUNT")"
+sleep 1.1; touch "$dep"
+check dep-invalidates "2" "$(run "_cached_eval -d ${(q)dep} faketool && print \$FAKE_COUNT")"
+
+# corrupt cache (bad header) regenerates instead of sourcing garbage
+print 'utter garbage (((' > "$cache_file"
+check corrupt-recovery "3" "$(run '_cached_eval faketool && print $FAKE_COUNT' 2>/dev/null)"
+
+# unwritable cache dir: regeneration impossible -> live-eval fallback, no error
+sleep 1.1; touch "$work/bin/faketool"
+chmod a-w "$XDG_CACHE_HOME/zsh-eval-cache"
+check readonly-fallback "4" "$(run '_cached_eval faketool && print $FAKE_COUNT')"
+chmod u+w "$XDG_CACHE_HOME/zsh-eval-cache"
+
+# missing binary returns 1
+check missing-binary "1" "$(run '_cached_eval no-such-tool-xyz; print $?')"
+
+# setopt in the tool's output must land in the caller's shell, not get
+# localized away (starship emits `setopt promptsubst`)
+cat > "$work/bin/setopttool" <<'EOF'
+#!/bin/sh
+echo "setopt promptsubst"
+EOF
+chmod +x "$work/bin/setopttool"
+check setopt-escapes "on" \
+  "$(run '_cached_eval setopttool; [[ -o promptsubst ]] && print on || print off')"
+
+# 6-way concurrent cold start: atomic writes mean no shell ever sources a
+# torn cache, and the surviving cache file is valid
+rm -f "$cache_file"
+concurrent_out="$work/concurrent"
+for i in 1 2 3 4 5 6; do
+  run '_cached_eval faketool && print $FAKE_COUNT' >> "$concurrent_out" &
+done
+wait
+check concurrent-all-succeed "6" "$(wc -l < "$concurrent_out" | tr -d ' ')"
+first_line="$(head -1 "$cache_file")"
+check concurrent-cache-valid "yes" \
+  "$([[ $first_line == '# _cached_eval: faketool -> '* ]] && print yes || print no)"
+
+(( fails == 0 )) && { print "all passed"; exit 0 } || { print "$fails failed"; exit 1 }

--- a/tests/zellij-gc.test.zsh
+++ b/tests/zellij-gc.test.zsh
@@ -1,0 +1,61 @@
+#!/usr/bin/env zsh
+# Throttle and flag behavior for zellij-gc. Needs no zellij binary: the script
+# exits right after the throttle logic when zellij is absent, so whether the
+# throttle stamp got (re)written proves which side of the throttle a run
+# landed on. Regression test for the extended_glob bug that made the throttle
+# always fire — with it, the first run below never writes the stamp.
+# Self-contained: `zsh -f tests/zellij-gc.test.zsh`. Exits non-zero on failure.
+set -u
+zmodload zsh/datetime
+
+script_dir="${0:A:h}"
+gc="$script_dir/../modules/zellij/zellij-gc"
+
+work="$(mktemp -d)"
+trap 'rm -rf -- "$work"' EXIT
+export XDG_CACHE_HOME="$work"
+path=(/usr/bin /bin)  # hide zellij even if installed
+
+logdir="$work/cmux-zellij"
+stamp="$logdir/gc-last-run"
+
+fails=0
+check() {
+  if [[ $2 == "$3" ]]; then
+    print "ok   $1"
+  else
+    print "FAIL $1: expected [$2] got [$3]"
+    (( fails++ ))
+  fi
+}
+
+# first run ever (no stamp): must pass the throttle and write the stamp
+zsh -f "$gc"
+check first-run-passes-throttle "yes" "$([[ -f $stamp ]] && print yes || print no)"
+
+# immediate second run: fresh stamp throttles, stamp content untouched
+before="$(<"$stamp")"
+sleep 1.1
+zsh -f "$gc"
+check fresh-stamp-throttles "$before" "$(<"$stamp")"
+
+# stale stamp (7h old mtime): throttle expired, gc runs and rewrites the stamp
+touch -t "$(strftime '%Y%m%d%H%M' $(( EPOCHSECONDS - 7 * 3600 )))" "$stamp"
+zsh -f "$gc"
+check stale-stamp-runs "yes" "$([[ "$(<"$stamp")" != "$before" ]] && print yes || print no)"
+
+# --dry-run on a clean slate: touches neither the stamp nor gc.log
+rm -rf -- "$logdir"
+zsh -f "$gc" --dry-run
+check dry-run-no-stamp "no" "$([[ -e $stamp ]] && print yes || print no)"
+check dry-run-no-log "no" "$([[ -e $logdir/gc.log ]] && print yes || print no)"
+
+# unknown flag: usage error
+zsh -f "$gc" --bogus 2>/dev/null
+check unknown-flag-exit-2 "2" "$?"
+
+# non-numeric stale-hours env must not error (falls back to the default)
+err="$(CMUX_ZELLIJ_GC_STALE_HOURS=abc zsh -f "$gc" --force 2>&1)"
+check bad-stale-hours-silent "" "$err"
+
+(( fails == 0 )) && { print "all passed"; exit 0 } || { print "$fails failed"; exit 1 }


### PR DESCRIPTION
Follow-up to #54, which merged before its review concluded. Fixes all nine inline findings from the [review](https://github.com/DJRHails/dotfiles/pull/54#pullrequestreview-4678821298).

## Headline (P1)

**`zellij-gc` never ran in production.** `(#q...)` glob qualifiers require `extended_glob`, which is off under `zsh -f` (how auto-attach spawns it), so `[[ -n $throttle_stamp(#qN.mh-6) ]]` was a literal non-empty string — always true — and every flagless run exited at the throttle before reaping anything. `--dry-run`/`--force` bypass that check, which is why manual testing looked healthy. Reproduced on zsh 5.9 with a fresh stamp, a 10h-old stamp, and no stamp at all. Fix: `setopt extended_glob`.

## Also fixed

- **compinit gate** (P2): same `extended_glob` bug made `compinit -C` dead code — full compinit ran every shell. Now an anonymous function with `localoptions extendedglob`, inverted polarity (fresh dump → `-C`), and a `touch` after full compinit so the 24h clock actually advances.
- **zprofile brew caching** (P2): `brew shellenv` prints ~nothing when `HOMEBREW_PREFIX` is already set, so a nested login shell could cache an empty body and starve every fresh login shell of brew env. Whole block now guarded on `HOMEBREW_PREFIX` being unset.
- **`_cached_eval` `emulate -L`** (P2): localized `setopt`/`typeset` from sourced init output (starship emits `setopt promptsubst` — currently masked only by config.zsh's independent `PROMPT_SUBST`). Dropped; all vars were already `local`.
- **gc EXITED sweep** (P2): missing stamp deleted records immediately, and a reap + delete could destroy resurrectable state in one pass. Reaping now resets the stamp (7-day window starts at exit); missing stamps get seeded, never immediate-deleted. Detach in auto-attach also refreshes the stamp.
- **gc busy check** (P3): direct non-shell server children (`zellij run -- cmd`, exec'd programs) counted as idle; now they count busy.
- **silent missing sheldon** (P3): now warns instead of silently skipping all plugins.
- **gc robustness** (P3): non-numeric `CMUX_ZELLIJ_GC_STALE_HOURS` falls back to 48 (previously errored into reaping *fresh* sessions); `--dry-run` no longer writes gc.log; `run complete reaped=N deleted=N` breadcrumb.
- **`_cached_eval` cache-fill** (P3): tool stderr passes through instead of being swallowed into a persistently-cached degraded state; header now records argv so distinct invocations can't collide on one cache file.

## Tests

#54's description claimed a behavior suite that was never committed. Now in-tree, self-contained (`zsh -f tests/<name>.test.zsh`):

- `tests/cached-eval.test.zsh` — cold/warm/binary-upgrade/dep-invalidation/corrupt-cache/read-only dir/missing binary/setopt-escape/6-way concurrent cold start. **12/12 pass.**
- `tests/zellij-gc.test.zsh` — throttle first-run/fresh/stale, dry-run purity, unknown flag, bad stale-hours env. **7/7 pass — and 2 fail against the pre-fix script** (falsification of the P1).

Verification beyond the suites: `zsh -n` on all changed files; full interactive login boot simulated with the changed zshenv/zprofile/zshrc pieces (compinit branch selection, `extendedglob` not leaking, `compdef` defined); busy-check comm classification exercised against live pids; gitleaks + trufflehog clean.