### PR TITLE
fix: resolve post-merge review findings for PR #56 — zellij-gc sidecar leak + vacuous test

### DIFF
--- a/modules/zellij/zellij-gc
+++ b/modules/zellij/zellij-gc
@@ -142,8 +142,12 @@ for sess in $(zellij list-sessions 2>/dev/null | perl -pe 's/\e\[[0-9;]*m//g' \
   (( last > exited_before )) && continue
   if (( dry_run )); then
     log "would-delete exited sess=$sess"
-  else
-    zellij delete-session "$sess" >/dev/null 2>&1 && log "deleted exited sess=$sess"
+  elif zellij delete-session "$sess" >/dev/null 2>&1; then
+    # The record is gone; drop its sidecar files too (the stamp, plus
+    # auto-attach's live-ids), else every deletion strands one file in the
+    # very directory this script exists to keep bounded.
+    rm -f -- "$stamp" "$logdir/live-$sess" 2>/dev/null
+    log "deleted exited sess=$sess"
   fi
   (( deleted++ ))
 done

--- a/tests/zellij-gc.test.zsh
+++ b/tests/zellij-gc.test.zsh
@@ -1,9 +1,12 @@
 #!/usr/bin/env zsh
-# Throttle and flag behavior for zellij-gc. Needs no zellij binary: the script
-# exits right after the throttle logic when zellij is absent, so whether the
-# throttle stamp got (re)written proves which side of the throttle a run
-# landed on. Regression test for the extended_glob bug that made the throttle
-# always fire — with it, the first run below never writes the stamp.
+# Throttle, flag, and EXITED-sweep behavior for zellij-gc. The throttle checks
+# need no zellij binary: the script exits right after the throttle logic when
+# zellij is absent, so whether the throttle stamp got (re)written proves which
+# side of the throttle a run landed on. Regression test for the extended_glob
+# bug that made the throttle always fire — with it, the first run below never
+# writes the stamp. The sweep checks run against stub zellij/ps binaries so
+# they exercise the real script without seeing (or signalling) real sessions
+# on the machine running this suite.
 # Self-contained: `zsh -f tests/zellij-gc.test.zsh`. Exits non-zero on failure.
 set -u
 zmodload zsh/datetime
@@ -54,8 +57,38 @@ check dry-run-no-log "no" "$([[ -e $logdir/gc.log ]] && print yes || print no)"
 zsh -f "$gc" --bogus 2>/dev/null
 check unknown-flag-exit-2 "2" "$?"
 
-# non-numeric stale-hours env must not error (falls back to the default)
-err="$(CMUX_ZELLIJ_GC_STALE_HOURS=abc zsh -f "$gc" --force 2>&1)"
+# The remaining checks need the script to get past its `command -v zellij`
+# exit: stub zellij (reports one EXITED cmux session), and stub ps to print
+# nothing so the reap loop can never see real servers.
+stub="$work/stub-bin"
+mkdir -p "$stub"
+cat > "$stub/zellij" <<'EOF'
+#!/bin/sh
+[ "$1" = list-sessions ] && echo "cmux-gc-test-dead [Created 30days ago] (EXITED - attach to resurrect)"
+exit 0
+EOF
+cat > "$stub/ps" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$stub/zellij" "$stub/ps"
+
+# non-numeric stale-hours env must not error (falls back to the default).
+# Needs the zellij stub — without it the script exits before the arithmetic
+# that a bad value breaks, and this check can't fail. stderr only: dry-run's
+# would-seed chatter on stdout is expected.
+err="$(CMUX_ZELLIJ_GC_STALE_HOURS=abc PATH="$stub:$PATH" zsh -f "$gc" --dry-run 2>&1 >/dev/null)"
 check bad-stale-hours-silent "" "$err"
+
+# EXITED record first seen without a stamp: seeded now, not deleted
+PATH="$stub:$PATH" zsh -f "$gc" --force
+check exited-no-stamp-seeded "yes" "$([[ -f $logdir/last-cmux-gc-test-dead ]] && print yes || print no)"
+
+# stamp aged past 7 days: record deleted and its sidecar files cleaned up
+print $(( EPOCHSECONDS - 8 * 86400 )) > "$logdir/last-cmux-gc-test-dead"
+print "ws-id sf-id" > "$logdir/live-cmux-gc-test-dead"
+PATH="$stub:$PATH" zsh -f "$gc" --force
+check exited-stale-stamp-removed "no" "$([[ -e $logdir/last-cmux-gc-test-dead ]] && print yes || print no)"
+check exited-stale-live-removed "no" "$([[ -e $logdir/live-cmux-gc-test-dead ]] && print yes || print no)"
 
 (( fails == 0 )) && { print "all passed"; exit 0 } || { print "$fails failed"; exit 1 }


### PR DESCRIPTION
Follow-up to #56 (merged before this post-merge review concluded). Fixes both inline findings from the [review](https://github.com/DJRHails/dotfiles/pull/56#pullrequestreview-4678859812), each verified by falsification — the new/changed tests fail against the pre-fix script.

## Sidecar-file leak on EXITED delete (P3, finding F2)

`zellij delete-session` removed the record but stranded `$logdir/last-<sess>` (and auto-attach's `live-<sess>`) forever — and #56's stamp seeding guaranteed every record had a stamp by deletion time, so **every delete leaked exactly one file** into the directory the GC exists to keep bounded. Both sidecars are now removed on successful delete.

## Vacuous `bad-stale-hours-silent` test (P2, finding F1)

The arithmetic a non-numeric `CMUX_ZELLIJ_GC_STALE_HOURS` breaks (`stale_before=$(( now - stale_hours * 3600 ))`) sits *after* the `command -v zellij || exit 0` gate, and the suite deliberately hides zellij — so the check passed even with the guard reverted. It now runs against a stub `zellij` (as `--dry-run`, capturing stderr only) so execution reaches the arithmetic; a stub `ps` guarantees the reap loop can never see — or signal — real servers on a machine running the suite.

## New coverage

First tests for the EXITED sweep: a no-stamp record gets seeded (not deleted); a record whose stamp aged past 7 days is deleted **with** its sidecar files.

## Verification

- `zsh -n` on both changed files
- `tests/zellij-gc.test.zsh` **10/10** (8 consecutive clean runs); `tests/cached-eval.test.zsh` **12/12**
- Falsification: against merged main's `zellij-gc` the two sidecar checks fail; against a guard-reverted variant, `bad-stale-hours-silent` additionally fails with `abc: parameter not set` — previously it passed vacuously
- gitleaks (staged) + trufflehog (filesystem) clean
