### PR TITLE
feat(zsh): auto-load direnv per directory (cached)

### DIFF
--- a/modules/zsh/zshrc.tmpl
+++ b/modules/zsh/zshrc.tmpl
@@ -106,3 +106,8 @@ export PATH=${PATH:+$PATH:}${DOTFILES}/bin
 
 # Starship prompt (cached: skips the ~40ms init subprocess; see zshenv)
 (( $+commands[starship] )) && _cached_eval starship init zsh
+
+# direnv: auto-load .envrc (which dotenvs .env) per directory, cached like
+# starship (see zshenv's _cached_eval). Guarded on $+commands so it no-ops
+# on hosts where direnv isn't installed.
+(( $+commands[direnv] )) && _cached_eval direnv hook zsh


### PR DESCRIPTION
Adds a guarded, `_cached_eval`'d `direnv hook zsh` to the zshrc template so every machine gets per-directory `.envrc` auto-loading on next render.

- Guarded on `$+commands[direnv]` → no-ops on hosts without direnv installed.
- Cached via `_cached_eval` like the starship init line above it.
- Previously direnv was hand-added to the *generated* `zshrc` on bonbon, which broke the `.zshrc.sha256` guard and froze template updates. This moves it to the tracked source.