### PR TITLE
fix(zsh): don't leak direnv guard status 1 into first prompt

### DIFF
--- a/modules/zsh/zshrc.tmpl
+++ b/modules/zsh/zshrc.tmpl
@@ -108,6 +108,9 @@ export PATH=${PATH:+$PATH:}${DOTFILES}/bin
 (( $+commands[starship] )) && _cached_eval starship init zsh
 
 # direnv: auto-load .envrc (which dotenvs .env) per directory, cached like
-# starship (see zshenv's _cached_eval). Guarded on $+commands so it no-ops
-# on hosts where direnv isn't installed.
-(( $+commands[direnv] )) && _cached_eval direnv hook zsh
+# starship (see zshenv's _cached_eval). `if` rather than `guard && cmd`
+# because this is the file's last command: a failed `&&` guard would leak
+# status 1 into the first precmd, and starship paints its prompt red on it.
+if (( $+commands[direnv] )); then
+  _cached_eval direnv hook zsh
+fi


### PR DESCRIPTION
Fixes finding F1 from the post-merge review of #58 ([inline thread](https://github.com/DJRHails/dotfiles/pull/58#discussion_r3586965391)).

**Problem:** the direnv line added in #58 is the last command in the generated zshrc. On hosts without direnv, `(( $+commands[direnv] )) && …` short-circuits with status 1; zsh hands that status to the first precmd, and starship (initialized two lines up) captures it as `STARSHIP_CMD_STATUS`, painting the red `error_symbol` on every new shell. No zlogin exists in this repo, so nothing resets the status after zshrc.

**Fix:** use the `if` form — a failed `if` with no `else` returns 0. Also adds the missing trailing newline at EOF.

**Verification:**
- Empirical repro: with the old `&&` form, first precmd sees `$?=1` when direnv is absent; with the `if` form it sees `$?=0`.
- Rendered template passes `zsh -n` and sources cleanly (exit 0).
- Both test suites pass (`tests/cached-eval.test.zsh`, `tests/zellij-gc.test.zsh`).
- Pre-commit hooks (gitleaks, trufflehog, check-crypt-patterns) all passed.

_[via gantry](https://gantry.hails.info/run/keen-lush-crane)_
