### PR TITLE
fix(zsh): self-contained open alias, platform::open never loads

### DIFF
--- a/modules/zsh/aliases.zsh
+++ b/modules/zsh/aliases.zsh
@@ -6,7 +6,12 @@ alias cls='clear' # Good 'ol Clear Screen command
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-alias open='platform::open'
+# macOS ships /usr/bin/open natively; on Linux map `open` to xdg-open.
+# (scripts/core/platform.sh is installer-only — its platform::open never
+# exists in interactive shells, so aliasing to it broke `open` entirely.)
+if [[ "$(uname -s)" == "Linux" ]] && (( $+commands[xdg-open] )); then
+  alias open='xdg-open'
+fi
 
 if [[ "$(uname -s)" == "Linux" ]] && (( $+commands[trash-put] )); then
   alias trash='trash-put'


### PR DESCRIPTION
`alias open='platform::open'` pointed at a function defined only in `scripts/core/platform.sh`, which the interactive startup chain never sources (`zshrc` globs `modules/*/*.zsh` only) — so every `open` died with `command not found: platform::open`, shadowing macOS's native `/usr/bin/open`.

Latent second bug: even if `platform.sh` were sourced, its macOS fallback calls `open`, which the alias re-expands to `platform::open` at definition time — infinite recursion.

Fix: replace the alias with the same idiom as the `trash-put` guard directly below it — macOS keeps native `open`; Linux gets `alias open='xdg-open'` when available. `platform::open` stays for the installer scripts that actually source it.

Verified: `zsh -ic 'type open'` → `open is /usr/bin/open`.