### PR TITLE
feat(skills): worktree skill learns in-place dangling-worktree recovery

### DIFF
--- a/modules/agents/skills/worktree/SKILL.md
+++ b/modules/agents/skills/worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worktree
-description: Manage git worktrees — setup and cleanup. Use when the user asks to clean up, prune, create, or sync worktrees, create worktrees for open PRs, or create a worktree. Also load proactively when the session starts inside a worktree (working directory contains .data/worktrees/).
+description: Manage git worktrees — setup, cleanup, and recovery. Use when the user asks to clean up, prune, create, or sync worktrees, create worktrees for open PRs, or create a worktree — and whenever a git command inside a worktree fails with "fatal: not a git repository ... .git/worktrees/<name>" (dangling worktree; recover in place, do not delete it). Also load proactively when the session starts inside a worktree (working directory contains .data/worktrees/).
 ---
 
 # Worktree Management
@@ -137,6 +137,50 @@ Copied:   12 node_modules (CoW) across 3 worktrees
 ```
 
 ---
+
+## Recovering a dangling worktree
+
+Symptom: every git command inside a worktree fails with
+
+```
+fatal: not a git repository: <repo-root>/.git/worktrees/<name>
+```
+
+while the worktree's working files are all still there. The worktree's admin
+dir (`.git/worktrees/<name>` — its HEAD, index, and back-pointer) was removed
+from the parent checkout while the worktree directory survived. On gantry
+workers this is the normal container lifecycle, not sabotage: the checkout's
+`.git` dies with the container and is re-cloned fresh on rebuild, while
+`.data/` (including `.data/worktrees/`) persists — so after an idle reap or
+image rebuild every worktree dangles exactly like this. It also happens
+anywhere the parent repo was re-cloned or its `.git` rebuilt.
+
+**Recover in place** — do NOT delete the worktree and re-add it (the mv-aside
+dance loses nothing but wastes minutes and risks the uncommitted files).
+Reconstruct the admin dir instead; working files, uncommitted edits included,
+are untouched:
+
+```bash
+name=<worktree-name> branch=<branch>
+cd "$(git rev-parse --show-toplevel)"   # the parent checkout
+# if this root checkout has $branch checked out, detach it first:
+#   git checkout --detach
+git branch -f "$branch" "origin/$branch"
+mkdir -p ".git/worktrees/$name"
+echo "$PWD/.data/worktrees/$name/.git" > ".git/worktrees/$name/gitdir"
+echo "ref: refs/heads/$branch" > ".git/worktrees/$name/HEAD"
+echo "../.." > ".git/worktrees/$name/commondir"
+git -C ".data/worktrees/$name" reset -q
+```
+
+`git status` in the worktree then shows the surviving uncommitted work as the
+delta against the pushed tip. Caveats:
+
+- Unpushed commits are only recoverable if the parent's object store still has
+  them; after a fresh re-clone they are gone — the pushed tip is the best
+  possible base. (On gantry: push early and often.)
+- Pick `origin/$branch` deliberately: everything committed-but-unpushed shows
+  up as uncommitted changes against it, which is correct, not data loss.
 
 ## Notes
 

--- a/modules/agents/skills/worktree/SKILL.md
+++ b/modules/agents/skills/worktree/SKILL.md
@@ -170,6 +170,8 @@ mkdir -p ".git/worktrees/$name"
 echo "$PWD/.data/worktrees/$name/.git" > ".git/worktrees/$name/gitdir"
 echo "ref: refs/heads/$branch" > ".git/worktrees/$name/HEAD"
 echo "../.." > ".git/worktrees/$name/commondir"
+# re-point the worktree at THIS checkout (no-op unless the repo root moved)
+echo "gitdir: $PWD/.git/worktrees/$name" > ".data/worktrees/$name/.git"
 git -C ".data/worktrees/$name" reset -q
 ```
 


### PR DESCRIPTION
Companion to [gantry #516](https://github.com/DJRHails/gantry/pull/516) — see it for the full incident diagnosis ([run merry-kind-rapid](https://gantry.hails.info/run/merry-kind-rapid)'s worktree feedback).

On gantry workers the checkout's `.git` dies with the container while `.data/worktrees/` persists in the repo-data bind, so after an idle reap or image rebuild every worktree dangles — `fatal: not a git repository: …/.git/worktrees/<name>` — with its working files intact. The affected worker burned two sessions rediscovering this and misattributed it to a PR-review bot pushing to its branch.

This teaches the `worktree` skill:

- a **Recovering a dangling worktree** section: recognise the symptom, explain the gantry lifecycle cause, and recover **in place** by reconstructing the admin dir (`gitdir`/`HEAD`/`commondir` + `git -C <wt> reset`) — keeps uncommitted edits, no mv-aside/re-add dance. Recipe verified in a lab repo (delete `.git/worktrees` + branch ref → recover → `worktree list`/`status`/`commit` all work, uncommitted files intact).
- a description trigger on the error message so the skill loads when an agent first hits it.

_[via gantry](https://gantry.hails.info/run/scarlet-sharp-basin)_