### PR TITLE
pi: pin subagents to claude-opus-5[fast]

### DIFF
--- a/modules/agents/AGENTS.md
+++ b/modules/agents/AGENTS.md
@@ -175,7 +175,7 @@ Pin actions to version tags: `actions/checkout@v4` (use `persist-credentials: fa
   fit the task — no Opus pin.** `anthropic-api` uses the load-balanced `ANTHROPIC_API_KEY_*` keys
   and works wherever they resolve. **Any registered `anthropic-api` model works, including non-Opus
   (`claude-fable-5`, `claude-haiku-4-5`, `claude-sonnet-5`)** — use a cheap/small model for recon,
-  reviews, and parallel fan-out; reserve `claude-opus-4-8[fast]` for work that needs the frontier.
+  reviews, and parallel fan-out; reserve `claude-opus-5[fast]` for work that needs the frontier.
   The old "always pin to `claude-opus-4-8[fast]`" rule was a *workaround* for a real bug, fixed by
   `DJRHails/pi-interactive-subagents` PRs #9 and #12 (still open as of 2026-07-24, not yet on
   `main`): a bare/ambiguous model id (e.g. `claude-fable-5`) fell through to pi's keyless built-in

--- a/modules/pi/agents/planner.md
+++ b/modules/pi/agents/planner.md
@@ -1,4 +1,4 @@
 ---
 name: planner
-model: claude-opus-4-8[fast]
+model: claude-opus-5[fast]
 ---

--- a/modules/pi/agents/reviewer.md
+++ b/modules/pi/agents/reviewer.md
@@ -1,4 +1,4 @@
 ---
 name: reviewer
-model: claude-opus-4-8[fast]
+model: claude-opus-5[fast]
 ---

--- a/modules/pi/agents/scout.md
+++ b/modules/pi/agents/scout.md
@@ -1,4 +1,4 @@
 ---
 name: scout
-model: claude-opus-4-8[fast]
+model: claude-opus-5[fast]
 ---

--- a/modules/pi/agents/visual-tester.md
+++ b/modules/pi/agents/visual-tester.md
@@ -1,4 +1,4 @@
 ---
 name: visual-tester
-model: claude-opus-4-8[fast]
+model: claude-opus-5[fast]
 ---

--- a/modules/pi/agents/worker.md
+++ b/modules/pi/agents/worker.md
@@ -1,4 +1,4 @@
 ---
 name: worker
-model: claude-opus-4-8[fast]
+model: claude-opus-5[fast]
 ---


### PR DESCRIPTION
All five pi subagent definitions still pinned `claude-opus-4-8[fast]`. Bump them to `claude-opus-5[fast]`, matching the default already set in `modules/pi/settings.json`.

Verified against `pi models`: `claude-opus-5[fast]` is registered on the `anthropic-api` provider (1M ctx / 128K out), so no ambiguous-id routing risk.

Note: `~/.pi/agent/agents/*.md` on this host are plain copies rather than the symlinks declared in `modules/pi/symlinks.conf` — they were updated in lockstep by hand. A `scripts/link.sh` run would re-establish the links.