### PR TITLE
feat(dotfiles-autoupdate): add dotfiles::update alias for manual pull

### DIFF
--- a/modules/dotfiles-autoupdate/README.md
+++ b/modules/dotfiles-autoupdate/README.md
@@ -13,6 +13,12 @@ timer, or cron fallback).
 Logs to `$XDG_STATE_HOME/dotfiles/autoupdate.log` (default
 `~/.local/state/dotfiles/autoupdate.log`).
 
+## Pull now
+
+`dotfiles::update` ([`aliases.zsh`](./aliases.zsh)) is the manual counterpart —
+same fast-forward-only, submodule-skipping pull, but run on demand and with
+git's output on the terminal instead of in the log.
+
 ## Install
 
 Picked up by `bootstrap.sh` (in the `--cli` server set, so bonbon/taffy get it

--- a/modules/dotfiles-autoupdate/aliases.zsh
+++ b/modules/dotfiles-autoupdate/aliases.zsh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Manual counterpart to the daily auto-update (update.sh, which is silent and
+# only writes to its log): pull ~/.files now, with git's output on the terminal.
+#
+# Same safety as the unattended pull — fast-forward only, so a diverged branch
+# is left for a human — and skips submodules, whose pinned state is managed
+# separately (`git submodule update` follows a bumped pin).
+alias dotfiles::update='git -C "${DOTFILES:-$HOME/.files}" pull --ff-only --prune --no-recurse-submodules'


### PR DESCRIPTION
Adds `dotfiles::update` — the on-demand counterpart to the daily auto-update.

```zsh
alias dotfiles::update='git -C "${DOTFILES:-$HOME/.files}" pull --ff-only --prune --no-recurse-submodules'
```

- Lives in `modules/dotfiles-autoupdate/aliases.zsh`, colocated with `update.sh`; picked up by zshrc's `modules/*/*.zsh` glob.
- Mirrors the unattended pull's safety: fast-forward only (a diverged branch stays for a human), no submodule recursion (pins are managed separately).
- Unlike `update.sh` (silent, log-only), git's output goes to the terminal.
- README gains a "Pull now" section.

Verified from `/tmp` with `DOTFILES` unset → `Already up to date.`
