### PR TITLE
fix(claude): drop fastMode so xhigh effort keeps thinking on

### DIFF
--- a/modules/claude/settings.ant.json
+++ b/modules/claude/settings.ant.json
@@ -146,7 +146,6 @@
   },
   "alwaysThinkingEnabled": true,
   "effortLevel": "xhigh",
-  "fastMode": true,
   "showThinkingSummaries": true,
   "skipDangerousModePermissionPrompt": true,
   "skipWorkflowUsageWarning": true,

--- a/modules/claude/settings.json
+++ b/modules/claude/settings.json
@@ -142,7 +142,6 @@
   },
   "alwaysThinkingEnabled": true,
   "effortLevel": "xhigh",
-  "fastMode": true,
   "skipDangerousModePermissionPrompt": true,
   "skipWorkflowUsageWarning": true,
   "theme": "dark",


### PR DESCRIPTION
## Problem

Every `WebSearch` call from a Claude Code worker was failing with:

> `400 output_config.effort 'xhigh' is not supported when thinking is disabled on this model`

## Root cause

The claude settings carried three flags together:

```jsonc
"alwaysThinkingEnabled": true,
"effortLevel": "xhigh",
"fastMode": true,     // <-- the culprit
```

- `fastMode` is a latency-over-quality speed axis; it disables extended thinking at request time (Anthropic's guidance is to pair fast mode with **low** effort).
- Per the [Effort docs](https://platform.claude.com/docs/en/build-with-claude/effort), on these Opus models **thinking cannot be disabled at `xhigh`/`max` effort** — such requests return a 400.
- Claude Code runs *detailed web search* at `xhigh` effort (the docs recommend xhigh "for exploratory tasks such as repeated tool calling, detailed web search"). So the web-search path hit `xhigh` + thinking-disabled → 400 on every call, while ordinary turns (resolved at `high`) were unaffected.

## Fix

Remove `fastMode: true` from both the default and `ant` profiles. `alwaysThinkingEnabled: true` + `effortLevel: xhigh` now form a coherent config — thinking stays on, so `xhigh` is valid and WebSearch works. Fast mode is the wrong trade for an xhigh coding profile regardless.

## Verification

- Reproduced the reported config running `fast_mode=on` under a headless `claude -p`; confirmed the fixed config runs `fast_mode=off` with thinking on, no API error, and a web-search task completing cleanly.
- Both files validated as JSON.

_[via gantry](https://gantry.hails.info/run/noble-scarlet-garnet)_